### PR TITLE
Add warm water functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,5 @@ workdir/
 test_pysimdeum.py
 unittest.house
 test.xlsx
+compare.xlsx
+testhot.xlsx

--- a/README.md
+++ b/README.md
@@ -88,11 +88,11 @@ consumption = house.simulate(num_patterns=100)
 
 The simulation result is an `xarray.DataArray` --- basically a labelled `numpy.ndarray` with four dimensions / axes (i.e., time, user, enduse, patterns).
 
-You can easily create statistics over the consumption object, for example, to compute the  average total consumption (sum of consumption of all users and enduses as an average over the patterns), you can build the sum over the `user` and `enduse` axes (the total consumption), and then build the mean over the `patterns` axes 
+You can easily create statistics over the consumption object, for example, to compute the  average total consumption (sum of consumption of all users and enduses as an average over the patterns), you can build the sum over the `user` and `enduse` axes (the total consumption), and then build the mean over the `patterns` axes. There are two `flowtypes` defined. `totalflow` and `hotflow`. `totalflow` reflects the total water use while `hotflow` reflects the water that has been heated up. 
 
 ```python
 # Build statistics from consumption
-tot_cons = consumption.sum(['enduse', 'user']).mean([ 'patterns'])
+tot_cons = consumption.sum(['enduse', 'user']).sel(flowtypes='totalflow').mean([ 'patterns'])
 ```
 
 If you want to plot the results pand additionally depict some rolling averages (e.g., hourly means = 3600 seconds), you can this in the following way

--- a/examples/minimal_example.py
+++ b/examples/minimal_example.py
@@ -17,7 +17,7 @@ print(house.appliances)
 consumption = house.simulate(num_patterns=100)
 
 # Build statistics from consumption
-tot_cons = consumption.sum(['enduse', 'user']).mean([ 'patterns'])
+tot_cons = consumption.sum(['enduse', 'user']).sel(flowtypes='totalflow').mean([ 'patterns'])
 print(tot_cons)
 
 # Plot total consumption

--- a/pysimdeum/core/end_use.py
+++ b/pysimdeum/core/end_use.py
@@ -14,6 +14,8 @@ class EndUse:
     
     statistics: Statistics = field(repr=False)  # ... statistic object associated with end-use
     name: str = "EndUse"  # ... name of the end-use
+    cold_water_temp = 10
+    hot_water_temp = 60
 
     def init_consumption(self, users: list=None, time_resolution: str='1s') -> pd.DataFrame:
         """Initialization of a pandas dataframe to store the  consumptions.
@@ -73,14 +75,20 @@ class EndUse:
         """Placeholder for specific intensity probability function defined in specific EndUse"""
 
         raise NotImplementedError('Intensity function is not implemented yet!')
+    
+    def temperature(self):
+        """Placeholder for specific temperature function defined in specific EndUse"""
 
-    def fct_duration_intensity(self):
-        """Computing duration and intensity for enduse"""
+        raise NotImplementedError('temperature function is not implemented yet!')
+
+    def fct_duration_intensity_temperature(self):
+        """Computing duration and intensity for enduse and retrieve temperature for enduse"""
 
         duration = self.fct_duration()
         intensity = self.fct_intensity()
+        temperature = self.temperature()
 
-        return duration, intensity
+        return duration, intensity, temperature
 
 @dataclass
 class Bathtub(EndUse):
@@ -133,6 +141,16 @@ class Bathtub(EndUse):
         """
         # fixed intensity
         return self.statistics['intensity']
+    
+    def temperature(self):
+        """Obtain the temperature of a bath
+
+        Returns:
+            temperature of bath water
+        
+        """
+        # independent of subtype
+        return self.statistics['temperature']
 
     def simulate(self, consumption, users=None, ind_enduse=None, pattern_num=1, day_num=0):
 
@@ -144,14 +162,16 @@ class Bathtub(EndUse):
 
             for i in range(freq):
 
-                duration, intensity = self.fct_duration_intensity()
+                duration, intensity, temperature = self.fct_duration_intensity_temperature()
+                temperature = self.statistics['temperature']
                 prob_joint = normalize(prob_user * prob_usage)
 
                 u = np.random.uniform()
                 start = np.argmin(np.abs(np.cumsum(prob_joint) - u)) + int(pd.to_timedelta('1 day').total_seconds())*day_num
                 end = start + duration
-
-                consumption[start:end, j, ind_enduse, pattern_num] = intensity
+                consumption[start:end, j, ind_enduse, pattern_num, 0] = intensity
+                temperature_fraction = (temperature - self.cold_water_temp)/(self.hot_water_temp - self.cold_water_temp)
+                consumption[start:end, j, ind_enduse, pattern_num, 1] = intensity*temperature_fraction
 
         return consumption
 
@@ -169,7 +189,7 @@ class BathroomTap(EndUse):
         average = f_stats['average']
         return distribution(average)
 
-    def fct_duration_intensity(self):
+    def fct_duration_intensity_temperature(self):
 
         subtype = chooser(self.statistics['subtype'], 'penetration')
 
@@ -185,8 +205,8 @@ class BathroomTap(EndUse):
         high = i_stats['high']
 
         intensity = dist(low=low, high=high)
-
-        return duration, intensity
+        temperature = self.statistics['subtype'][subtype]['temperature']
+        return duration, intensity, temperature
 
     def simulate(self, consumption, users=None, ind_enduse=None, pattern_num=1, day_num=0):
 
@@ -198,14 +218,16 @@ class BathroomTap(EndUse):
 
             for i in range(freq):
 
-                duration, intensity = self.fct_duration_intensity()
+                duration, intensity, temperature = self.fct_duration_intensity_temperature()
 
                 prob_joint = normalize(prob_user * prob_usage)
 
                 u = np.random.uniform()
                 start = np.argmin(np.abs(np.cumsum(prob_joint) - u)) + int(pd.to_timedelta('1 day').total_seconds())*day_num
                 end = int(start + duration)
-                consumption[start:end, j, ind_enduse, pattern_num] = intensity
+                consumption[start:end, j, ind_enduse, pattern_num, 0] = intensity
+                temperature_fraction = (temperature - self.cold_water_temp)/(self.hot_water_temp - self.cold_water_temp)
+                consumption[start:end, j, ind_enduse, pattern_num, 1] = intensity*temperature_fraction
 
         return consumption
 
@@ -256,7 +278,8 @@ class Dishwasher(EndUse):
             if end > (24 * 60 * 60):  #ToDo: Find better way to simulate dishwashers that are turned on in the night
                 end = 24 * 60 * 60
             difference = end - start
-            consumption[start:end, j, ind_enduse, pattern_num] = pattern[:difference]
+            consumption[start:end, j, ind_enduse, pattern_num, 0] = pattern[:difference] 
+            consumption[start:end, j, ind_enduse, pattern_num, 1] = 0
 
         return consumption
 
@@ -289,7 +312,7 @@ class KitchenTap(EndUse):
 
         return distribution(r, p)
 
-    def fct_duration_intensity(self):
+    def fct_duration_intensity_temperature(self):
 
         subtype = chooser(self.statistics['subtype'], 'penetration')
 
@@ -306,8 +329,9 @@ class KitchenTap(EndUse):
         high = i_stats['high']
 
         intensity = dist(low=low, high=high)
+        temperature = self.statistics['subtype'][subtype]['temperature']
 
-        return duration, intensity
+        return duration, intensity, temperature
 
     def simulate(self, consumption, users=None, ind_enduse=None, pattern_num=1, day_num=0):
 
@@ -327,12 +351,15 @@ class KitchenTap(EndUse):
 
         for i in range(freq):
 
-            duration, intensity = self.fct_duration_intensity()
+            duration, intensity, temperature = self.fct_duration_intensity_temperature()
             u = np.random.uniform()
             prob_joint = normalize(prob_user * prob_usage)  # ToDo: Check if joint probability can be computed outside of for loop for all functions
             start = np.argmin(np.abs(np.cumsum(prob_joint) - u)) + int(pd.to_timedelta('1 day').total_seconds())*day_num
             end = start + duration
-            consumption[start:end, j, ind_enduse, pattern_num] = intensity
+            consumption[start:end, j, ind_enduse, pattern_num, 0] = intensity
+            temperature_fraction = (temperature - self.cold_water_temp)/(self.hot_water_temp - self.cold_water_temp)
+            consumption[start:end, j, ind_enduse, pattern_num, 1] = intensity*temperature_fraction
+
 
         return consumption
 
@@ -349,7 +376,7 @@ class OutsideTap(EndUse):
         average = f_stats['average']
         return distribution(average)
 
-    def fct_duration_intensity(self):
+    def fct_duration_intensity_temperature(self):
 
         subtype = chooser(self.statistics['subtype'], 'penetration')
 
@@ -366,8 +393,9 @@ class OutsideTap(EndUse):
         high = i_stats['high']
 
         intensity = dist(low=low, high=high)
+        temperature = self.statistics['subtype'][subtype]['temperature']
 
-        return duration, intensity
+        return duration, intensity, temperature
 
     def simulate(self, consumption, users=None, ind_enduse=None, pattern_num=1, day_num=0):
 
@@ -387,14 +415,16 @@ class OutsideTap(EndUse):
 
         for i in range(freq):
 
-            duration, intensity = self.fct_duration_intensity()
+            duration, intensity, temperature = self.fct_duration_intensity_temperature()
 
             prob_joint = normalize(prob_user * prob_usage)
             u = np.random.uniform()
             start = np.argmin(np.abs(np.cumsum(prob_joint) - u)) + int(pd.to_timedelta('1 day').total_seconds())*day_num
             end = start + duration
 
-            consumption[start:end, j, ind_enduse, pattern_num] = intensity
+            consumption[start:end, j, ind_enduse, pattern_num, 0] = intensity
+            temperature_fraction = (temperature - self.cold_water_temp)/(self.hot_water_temp - self.cold_water_temp)
+            consumption[start:end, j, ind_enduse, pattern_num, 1] = intensity*temperature_fraction
 
         return consumption
 
@@ -413,7 +443,7 @@ class Shower(EndUse):
 
         return distribution(n, p)
 
-    def fct_duration_intensity(self, age=None):
+    def fct_duration_intensity_temperature(self, age=None):
 
         d_stats = self.statistics['duration']
         distribution = getattr(np.random, d_stats['distribution'].lower())
@@ -424,8 +454,9 @@ class Shower(EndUse):
         duration = int(pd.Timedelta(minutes=duration).total_seconds())
 
         intensity = self.statistics['subtype'][self.name]['intensity']
+        temperature = self.statistics['temperature']
 
-        return duration, intensity
+        return duration, intensity, temperature
 
     def simulate(self, consumption, users=None, ind_enduse=None, pattern_num=1, day_num=0):
 
@@ -436,13 +467,15 @@ class Shower(EndUse):
             prob_user = user.presence.values
 
             for i in range(freq):
-                duration, intensity = self.fct_duration_intensity(age=user.age)
+                duration, intensity, temperature = self.fct_duration_intensity_temperature(age=user.age)
 
                 prob_joint = normalize(prob_user * prob_usage)
                 u = np.random.uniform()
                 start = np.argmin(np.abs(np.cumsum(prob_joint) - u)) + int(pd.to_timedelta('1 day').total_seconds())*day_num
                 end = start + duration
-                consumption[start:end, j, ind_enduse, pattern_num] = intensity
+                consumption[start:end, j, ind_enduse, pattern_num, 0] = intensity
+                temperature_fraction = (temperature - self.cold_water_temp)/(self.hot_water_temp - self.cold_water_temp)
+                consumption[start:end, j, ind_enduse, pattern_num, 1] = intensity*temperature_fraction
 
         return consumption
 
@@ -507,7 +540,8 @@ class WashingMachine(EndUse):
             if end > (24 * 60 * 60):
                 end = 24 * 60 * 60
             difference = end - start
-            consumption[start:end, j, ind_enduse, pattern_num] = pattern[:difference]
+            consumption[start:end, j, ind_enduse, pattern_num, 0] = pattern[:difference]       
+            consumption[start:end, j, ind_enduse, pattern_num, 1] = 0
 
         return consumption
 
@@ -526,13 +560,13 @@ class Wc(EndUse):
 
         return distribution(average)
 
-    def fct_duration_intensity(self):
+    def fct_duration_intensity_temperature(self):
 
         flush_interuption = self.statistics['subtype'][self.name]['flush_interuption']
         prob_flush_interuption = self.statistics['prob_flush_interuption']
 
         intensity = self.statistics['intensity']
-
+        temperature = self.statistics['temperature']
         average = to_timedelta(self.statistics['subtype'][self.name]['duration'])
 
         # dist = duration_decorator(getattr(np.random, d_stats['distribution'].lower()))
@@ -545,7 +579,7 @@ class Wc(EndUse):
 
         duration = int(average.total_seconds())
 
-        return duration, intensity
+        return duration, intensity, temperature
 
 
     def simulate(self, consumption, users=None, ind_enduse=None, pattern_num=1, day_num=0):
@@ -558,13 +592,16 @@ class Wc(EndUse):
 
             for i in range(freq):
 
-                duration, intensity = self.fct_duration_intensity()
+                duration, intensity, temperature = self.fct_duration_intensity_temperature()
 
                 prob_joint = normalize(prob_user * prob_usage)
                 u = np.random.uniform()
                 start = np.argmin(np.abs(np.cumsum(prob_joint) - u)) + int(pd.to_timedelta('1 day').total_seconds())*day_num
                 end = start + duration
-                consumption[start:end, j, ind_enduse, pattern_num] = intensity
+                consumption[start:end, j, ind_enduse, pattern_num, 0] = intensity
+                temperature_fraction = (temperature - self.cold_water_temp)/(self.hot_water_temp - self.cold_water_temp)
+                consumption[start:end, j, ind_enduse, pattern_num, 1] = intensity*temperature_fraction
+
 
         return consumption
 

--- a/pysimdeum/core/house.py
+++ b/pysimdeum/core/house.py
@@ -281,14 +281,14 @@ class House(Property):
         users = [x.id for x in self.users] + ['household']
         enduse = [x.statistics['classname'] for x in self.appliances]
         patterns = [x for x in range(0, num_patterns)]
-        consumption = np.zeros((len(time), len(users), len(enduse), num_patterns))
+        flowtype = ['totalflow', 'hotflow']
+        consumption = np.zeros((len(time), len(users), len(enduse), num_patterns, len(flowtype)))
         number_of_days = int(timedelta/pd.to_timedelta('1 day'))
         for num in patterns:
             for k, appliance in enumerate(self.appliances):
                 for day in range(0, number_of_days, 1):
                     consumption = appliance.simulate(consumption, users=self.users, ind_enduse=k, pattern_num=num, day_num=day)
-
-        self.consumption = xr.DataArray(data=consumption, coords=[time, users, enduse, patterns], dims=['time', 'user', 'enduse', 'patterns'])
+        self.consumption = xr.DataArray(data=consumption, coords=[time, users, enduse, patterns, flowtype], dims=['time', 'user', 'enduse', 'patterns', 'flowtypes'])
 
         return self.consumption
 

--- a/pysimdeum/core/old_end_use.py
+++ b/pysimdeum/core/old_end_use.py
@@ -83,7 +83,7 @@ class EndUse(HasStrictTraits):
 
         raise NotImplementedError('Intensity function is not implemented yet!')
 
-    def fct_duration_intensity(self):
+    def fct_duration_intensity_temperature(self):
         """Computing duration and intensity for enduse"""
 
         duration = self.fct_duration()
@@ -154,7 +154,7 @@ class Bathtub(EndUse):
 
             for i in range(freq):
 
-                duration, intensity = self.fct_duration_intensity()
+                duration, intensity = self.fct_duration_intensity_temperature()
                 prob_joint = normalize(prob_user * prob_usage)
 
                 u = np.random.uniform()
@@ -188,7 +188,7 @@ class BathroomTap(EndUse):
         average = f_stats['average']
         return distribution(average)
 
-    def fct_duration_intensity(self):
+    def fct_duration_intensity_temperature(self):
 
         subtype = chooser(self.statistics['subtype'], 'penetration')
 
@@ -218,7 +218,7 @@ class BathroomTap(EndUse):
             for i in range(freq):
                 check = False
 
-                duration, intensity = self.fct_duration_intensity()
+                duration, intensity = self.fct_duration_intensity_temperature()
 
                 prob_joint = normalize(prob_user * prob_usage)
 
@@ -331,7 +331,7 @@ class KitchenTap(EndUse):
 
         return distribution(r, p)
 
-    def fct_duration_intensity(self):
+    def fct_duration_intensity_temperature(self):
 
         subtype = chooser(self.statistics['subtype'], 'penetration')
 
@@ -369,7 +369,7 @@ class KitchenTap(EndUse):
 
         for i in range(freq):
 
-            duration, intensity = self.fct_duration_intensity()
+            duration, intensity = self.fct_duration_intensity_temperature()
 
             prob_joint = normalize(prob_user * prob_usage)
 
@@ -407,7 +407,7 @@ class OutsideTap(EndUse):
         average = f_stats['average']
         return distribution(average)
 
-    def fct_duration_intensity(self):
+    def fct_duration_intensity_temperature(self):
 
         subtype = chooser(self.statistics['subtype'], 'penetration')
 
@@ -445,7 +445,7 @@ class OutsideTap(EndUse):
 
         for i in range(freq):
 
-            duration, intensity = self.fct_duration_intensity()
+            duration, intensity = self.fct_duration_intensity_temperature()
 
             prob_joint = normalize(prob_user * prob_usage)
 
@@ -487,7 +487,7 @@ class Shower(EndUse):
 
         return distribution(n, p)
 
-    def fct_duration_intensity(self, age=None):
+    def fct_duration_intensity_temperature(self, age=None):
 
         d_stats = self.statistics['duration']
         distribution = getattr(np.random, d_stats['distribution'].lower())
@@ -512,7 +512,7 @@ class Shower(EndUse):
             for i in range(freq):
                 check = False
 
-                duration, intensity = self.fct_duration_intensity(age=user.age)
+                duration, intensity = self.fct_duration_intensity_temperature(age=user.age)
 
                 prob_joint = normalize(prob_user * prob_usage)
 
@@ -628,7 +628,7 @@ class Wc(EndUse):
 
         return distribution(average)
 
-    def fct_duration_intensity(self):
+    def fct_duration_intensity_temperature(self):
 
         flush_interuption = self.statistics['subtype'][self.name]['flush_interuption']
         prob_flush_interuption = self.statistics['prob_flush_interuption']
@@ -663,7 +663,7 @@ class Wc(EndUse):
             for i in range(freq):
                 check = False
 
-                duration, intensity = self.fct_duration_intensity()
+                duration, intensity = self.fct_duration_intensity_temperature()
 
                 prob_joint = normalize(prob_user * prob_usage)
 

--- a/pysimdeum/data/NL/end_uses/KitchenTap.toml
+++ b/pysimdeum/data/NL/end_uses/KitchenTap.toml
@@ -39,7 +39,7 @@ distribution = 'Negative_binomial'
 
     [subtype.dishes]
         penetration = 25
-        tenperature = 55
+        temperature = 55
 
         [subtype.dishes.duration]
             average = '45 Seconds'

--- a/pysimdeum/data/NL/end_uses/Shower.toml
+++ b/pysimdeum/data/NL/end_uses/Shower.toml
@@ -3,6 +3,7 @@ classname = 'Shower'
 
 penetration = 100
 offset = '2 Hours'
+temperature = 40
 
 pattern = 'name of pattern generator'
 

--- a/pysimdeum/tools/helper.py
+++ b/pysimdeum/tools/helper.py
@@ -56,10 +56,10 @@ def create_usage_data(houses: Union[list, House]): #TODO I am not able to tell t
     return appliance_data, total_water_usage, total_users, total_number_of_days
 
 def _create_data(inputproperty):
-    total_water_usage = float(inputproperty.consumption.sum('user').sum('time').sum('enduse').sum('patterns').values)
+    total_water_usage = float(inputproperty.consumption.sel(flowtypes='totalflow').sum('user').sum('time').sum('enduse').sum('patterns').values)
     total_patterns = len(inputproperty.consumption.patterns)
     total_users = len(inputproperty.users)
-    appliance_data = inputproperty.consumption.sum('user').sum('time').sum('patterns').to_dataframe('total')
+    appliance_data = inputproperty.consumption.sel(flowtypes='totalflow').sum('user').sum('time').sum('patterns').to_dataframe('total')
     appliance_data['percentage'] = (appliance_data['total']/total_water_usage)*100
     appliance_data['pp'] = appliance_data['total']/total_users
     number_of_seconds = len(inputproperty.consumption)

--- a/pysimdeum/tools/plot.py
+++ b/pysimdeum/tools/plot.py
@@ -46,7 +46,7 @@ def createQcfdplot(houses: House):
     if type(houses) == House:
         n_bins = 100
         fig, ax = plt.subplots()
-        x = houses.consumption.sel(patterns=0).sum('user').sum('enduse').values
+        x = houses.consumption.sel(flowtypes='totalflow').sel(patterns=0).sum('user').sum('enduse').values
         n, bins, patches = ax.hist(x, n_bins, density=True, histtype='step',
                             cumulative=True, label='Empirical')
 
@@ -67,11 +67,13 @@ def plot_demand(houses: House):
     if type(houses) == House:
         fig, ((ax1, ax2), (ax3, ax4)) = plt.subplots(2,2, sharey=True)
         for user in houses.consumption.user.values:
-            ax1.plot(houses.consumption['time'].values, houses.consumption.sel(user=user, patterns=0).sum('enduse').values, label=user)
-        ax3.plot(houses.consumption['time'].values, houses.consumption.sel(patterns=0).sum('user').sum('enduse').values, label='total')
+            ax1.plot(houses.consumption['time'].values, houses.consumption.sel(flowtypes='totalflow').sel(user=user, patterns=0).sum('enduse').values, label=user)
+        ax3.plot(houses.consumption['time'].values, houses.consumption.sel(flowtypes='totalflow').sel(patterns=0).sum('user').sum('enduse').values, label='total flow pattern 0')
+        ax3.plot(houses.consumption['time'].values, houses.consumption.sel(flowtypes='hotflow').sel(patterns=0).sum('user').sum('enduse').values, label='hot flow pattern 0')
         for enduse in houses.consumption.enduse.values:
-            ax2.plot(houses.consumption['time'].values, houses.consumption.sel(enduse=enduse, patterns=0).sum('user').values, label=enduse)
-        ax4.plot(houses.consumption['time'].values, houses.consumption.sum('user').sum('enduse').sum('patterns').values/len(houses.consumption.patterns), label='average')
+            ax2.plot(houses.consumption['time'].values, houses.consumption.sel(flowtypes='totalflow').sel(enduse=enduse, patterns=0).sum('user').values, label=enduse)
+        ax4.plot(houses.consumption['time'].values, houses.consumption.sel(flowtypes='totalflow').sum('user').sum('enduse').sum('patterns').values/len(houses.consumption.patterns), label='average all patterns total flow')
+        ax4.plot(houses.consumption['time'].values, houses.consumption.sel(flowtypes='hotflow').sum('user').sum('enduse').sum('patterns').values/len(houses.consumption.patterns), label='average all patterns hot flow')
         ax1.legend()
         ax1.set_xlabel('time')
         ax1.set_ylabel('demand (l/s)')

--- a/testing/test_helper.py
+++ b/testing/test_helper.py
@@ -1,0 +1,52 @@
+import pandas as pd
+import numpy as np
+import xarray as xr
+import pytest
+from pysimdeum.tools.helper import _create_data
+
+def setUp():
+        # Mocking inputproperty for testing
+        class MockInputProperty:
+            def __init__(self, consumption, users):
+                self.consumption = consumption
+                self.users = users
+        
+        # Mocking consumption data
+        time = pd.date_range(start='2024-01-01', periods=10, freq='H')
+        patterns = ['pattern1', 'pattern2']
+        users = ['user1', 'user2']
+        data = np.random.rand(10, 2, 2, 2, 2)
+        consumption = xr.DataArray(data, dims=('time', 'user', 'enduse', 'patterns', 'flowtypes'), 
+                                    coords={'time': time, 'user': users, 'enduse': range(2),
+                                            'patterns': patterns, 'flowtypes': ['totalflow', 'hotflow']})
+        return MockInputProperty(consumption, users)
+    
+def test_create_data():
+    # Call the function with the mocked inputproperty
+    input = setUp()
+    appliance_data, total_water_usage, total_users, total_number_of_days, total_patterns = _create_data(input)
+    
+    # Assertions for total water usage
+    expected_total_water_usage = np.sum(input.consumption.sel(flowtypes='totalflow').values)
+    assert pytest.approx(total_water_usage) == expected_total_water_usage
+
+    # Assertions for total patterns
+    expected_total_patterns = len(input.consumption.patterns)
+    assert total_patterns == expected_total_patterns
+
+    # Assertions for total users
+    expected_total_users = len(input.users)
+    assert total_users == expected_total_users
+
+    # Assertions for appliance data
+    expected_appliance_data_total = input.consumption.sel(flowtypes='totalflow').sum('user').sum('time').sum('patterns').to_dataframe('total')
+    expected_appliance_data_total['percentage'] = (expected_appliance_data_total['total']/total_water_usage)*100
+    expected_appliance_data_total['pp'] = expected_appliance_data_total['total']/total_users
+    expected_appliance_data_total['pppd'] = (expected_appliance_data_total['pp']/total_patterns)/total_number_of_days
+    
+    pd.testing.assert_frame_equal(appliance_data, expected_appliance_data_total)
+
+    # Assertions for total number of days
+    expected_number_of_seconds = len(input.consumption)
+    expected_total_number_of_days = expected_number_of_seconds/(60*60*24)
+    assert pytest.approx(total_number_of_days) == expected_total_number_of_days


### PR DESCRIPTION
Added warm water functionality

Consumption array has an extra dimension: `flowtypes`. This has the values `totalflow` and `hotflow`. `totalflow` is the total water consumption while `hotflow` is just the heated part of the waterflow.

Each `end use` has, when applicable, a temperature set of the water outflow from which the percentage of hot waterflow (also with a fixed temperature) is calculated.

plot and write functions have been updated.

This is a **breaking change**. Due to the addition of an extra dimension to the consumption data array statements like (as in the example) `tot_cons = consumption.sum(['enduse', 'user']).mean([ 'patterns'])` need to be replaced by: `tot_cons = consumption.sum(['enduse', 'user']).sel(flowtypes='totalflow').mean([ 'patterns'])` to get the same results. the `.sel(flowtypes='totalflow')` part selects the totalflow array. by replacing this by `.sel(flowtypes='hotflow')` you gain access to just the hot water flow.