### PR TITLE
discharge BathroomTap

### DIFF
--- a/pysimdeum/api.py
+++ b/pysimdeum/api.py
@@ -11,6 +11,6 @@ def built_house(house_type: str = "") -> House:
     house.furnish_house()
     for user in house.users:
         user.compute_presence(statistics=stats)
-    house.simulate(num_patterns=100)
+    house.simulate(num_patterns=1, simulate_discharge=False)
 
     return house

--- a/pysimdeum/core/end_use.py
+++ b/pysimdeum/core/end_use.py
@@ -152,7 +152,7 @@ class Bathtub(EndUse):
         # independent of subtype
         return self.statistics['temperature']
 
-    def simulate(self, consumption, users=None, ind_enduse=None, pattern_num=1, day_num=0):
+    def simulate(self, consumption, discharge=None, users=None, ind_enduse=None, pattern_num=1, day_num=0, simulate_discharge=False):
 
         prob_usage = self.usage_probability().values
 
@@ -173,7 +173,7 @@ class Bathtub(EndUse):
                 temperature_fraction = (temperature - self.cold_water_temp)/(self.hot_water_temp - self.cold_water_temp)
                 consumption[start:end, j, ind_enduse, pattern_num, 1] = intensity*temperature_fraction
 
-        return consumption
+        return consumption, (discharge if simulate_discharge else None)
 
 
 @dataclass
@@ -191,10 +191,10 @@ class BathroomTap(EndUse):
 
     def fct_duration_intensity_temperature(self):
 
-        subtype = chooser(self.statistics['subtype'], 'penetration')
+        self.subtype = chooser(self.statistics['subtype'], 'penetration')
 
-        d_stats = self.statistics['subtype'][subtype]['duration']
-        i_stats = self.statistics['subtype'][subtype]['intensity']
+        d_stats = self.statistics['subtype'][self.subtype]['duration']
+        i_stats = self.statistics['subtype'][self.subtype]['intensity']
 
         dist = duration_decorator(getattr(np.random, d_stats['distribution'].lower()))
         mean = to_timedelta(np.log(to_timedelta(d_stats['average']).total_seconds()) - 0.5)
@@ -205,11 +205,35 @@ class BathroomTap(EndUse):
         high = i_stats['high']
 
         intensity = dist(low=low, high=high)
-        temperature = self.statistics['subtype'][subtype]['temperature']
+        temperature = self.statistics['subtype'][self.subtype]['temperature']
         return duration, intensity, temperature
+    
+    def calculate_discharge(self, discharge, start, duration, intensity, temperature_fraction, j, ind_enduse, pattern_num):
+        remaining_water = intensity * duration
+        start = int(start)
 
-    def simulate(self, consumption, users=None, ind_enduse=None, pattern_num=1, day_num=0):
+        # Sample a value from the discharge_intensity distribution
+        discharge_intensity_stats = self.statistics['subtype'][self.subtype]['discharge_intensity']
+        dist = getattr(np.random, discharge_intensity_stats['distribution'].lower())
+        low = discharge_intensity_stats['low']
+        high = discharge_intensity_stats['high']
+        discharge_flow_rate = dist(low=low, high=high)
 
+        # limit discharge_flow_rate to the intensity of the tap if there is not enough water to discharge
+        if discharge_flow_rate > intensity:
+            discharge_flow_rate = intensity
+
+        while remaining_water > 0:
+            discharge_duration = min(remaining_water / discharge_flow_rate, duration)
+            end = int(start + discharge_duration)            
+            discharge[start:end, j, ind_enduse, pattern_num, 0] = discharge_flow_rate
+            remaining_water -= discharge_flow_rate * discharge_duration
+            start = end
+
+        return discharge
+
+
+    def simulate(self, consumption, discharge, users=None, ind_enduse=None, pattern_num=1, day_num=0, simulate_discharge=False):
         prob_usage = self.usage_probability().values
 
         for j, user in enumerate(users):
@@ -229,7 +253,12 @@ class BathroomTap(EndUse):
                 temperature_fraction = (temperature - self.cold_water_temp)/(self.hot_water_temp - self.cold_water_temp)
                 consumption[start:end, j, ind_enduse, pattern_num, 1] = intensity*temperature_fraction
 
-        return consumption
+                if simulate_discharge:
+                    if discharge is None:
+                        raise ValueError("Discharge array is None. It must be initialized before being passed to the simulate function.")
+                    discharge = self.calculate_discharge(discharge, start, duration, intensity, temperature_fraction, j, ind_enduse, pattern_num)
+
+        return consumption, (discharge if simulate_discharge else None)
 
 @dataclass
 class Dishwasher(EndUse):
@@ -250,7 +279,7 @@ class Dishwasher(EndUse):
         pattern = self.statistics['enduse_pattern']
         return pattern
 
-    def simulate(self, consumption, users=None, ind_enduse=None, pattern_num=1, day_num=0):
+    def simulate(self, consumption, discharge=None, users=None, ind_enduse=None, pattern_num=1, day_num=0, simulate_discharge=False):
 
         prob_usage = copy.deepcopy(self.statistics['daily_pattern'].values)
         freq = self.fct_frequency(numusers=len(users))
@@ -281,7 +310,7 @@ class Dishwasher(EndUse):
             consumption[start:end, j, ind_enduse, pattern_num, 0] = pattern[:difference] 
             consumption[start:end, j, ind_enduse, pattern_num, 1] = 0
 
-        return consumption
+        return consumption, (discharge if simulate_discharge else None)
 
 @dataclass
 class KitchenTap(EndUse):
@@ -333,7 +362,7 @@ class KitchenTap(EndUse):
 
         return duration, intensity, temperature
 
-    def simulate(self, consumption, users=None, ind_enduse=None, pattern_num=1, day_num=0):
+    def simulate(self, consumption, discharge=None, users=None, ind_enduse=None, pattern_num=1, day_num=0, simulate_discharge=False):
 
         prob_usage = copy.deepcopy(self.statistics['daily_pattern'].values)
 
@@ -361,7 +390,7 @@ class KitchenTap(EndUse):
             consumption[start:end, j, ind_enduse, pattern_num, 1] = intensity*temperature_fraction
 
 
-        return consumption
+        return consumption, (discharge if simulate_discharge else None)
 
 @dataclass
 class OutsideTap(EndUse):
@@ -397,7 +426,7 @@ class OutsideTap(EndUse):
 
         return duration, intensity, temperature
 
-    def simulate(self, consumption, users=None, ind_enduse=None, pattern_num=1, day_num=0):
+    def simulate(self, consumption, discharge=None, users=None, ind_enduse=None, pattern_num=1, day_num=0, simulate_discharge=False):
 
         prob_usage = self.usage_probability().values
 
@@ -426,7 +455,7 @@ class OutsideTap(EndUse):
             temperature_fraction = (temperature - self.cold_water_temp)/(self.hot_water_temp - self.cold_water_temp)
             consumption[start:end, j, ind_enduse, pattern_num, 1] = intensity*temperature_fraction
 
-        return consumption
+        return consumption, (discharge if simulate_discharge else None)
 
 @dataclass
 class Shower(EndUse):
@@ -458,7 +487,7 @@ class Shower(EndUse):
 
         return duration, intensity, temperature
 
-    def simulate(self, consumption, users=None, ind_enduse=None, pattern_num=1, day_num=0):
+    def simulate(self, consumption, discharge=None, users=None, ind_enduse=None, pattern_num=1, day_num=0, simulate_discharge=False):
 
         prob_usage = self.usage_probability().values
 
@@ -477,7 +506,7 @@ class Shower(EndUse):
                 temperature_fraction = (temperature - self.cold_water_temp)/(self.hot_water_temp - self.cold_water_temp)
                 consumption[start:end, j, ind_enduse, pattern_num, 1] = intensity*temperature_fraction
 
-        return consumption
+        return consumption, (discharge if simulate_discharge else None)
 
 
 class NormalShower(Shower):
@@ -510,7 +539,7 @@ class WashingMachine(EndUse):
         # duration = pattern.index[-1] - pattern.index[0]
         return pattern
 
-    def simulate(self, consumption, users=None, ind_enduse=None, pattern_num=1, day_num=0):
+    def simulate(self, consumption, discharge=None, users=None, ind_enduse=None, pattern_num=1, day_num=0, simulate_discharge=False):
 
         prob_usage = copy.deepcopy(self.statistics['daily_pattern'].values)
 
@@ -543,7 +572,7 @@ class WashingMachine(EndUse):
             consumption[start:end, j, ind_enduse, pattern_num, 0] = pattern[:difference]       
             consumption[start:end, j, ind_enduse, pattern_num, 1] = 0
 
-        return consumption
+        return consumption, (discharge if simulate_discharge else None)
 
 @dataclass
 class Wc(EndUse):
@@ -582,7 +611,7 @@ class Wc(EndUse):
         return duration, intensity, temperature
 
 
-    def simulate(self, consumption, users=None, ind_enduse=None, pattern_num=1, day_num=0):
+    def simulate(self, consumption, discharge=None, users=None, ind_enduse=None, pattern_num=1, day_num=0, simulate_discharge=False):
 
         prob_usage = self.usage_probability().values
 
@@ -603,7 +632,7 @@ class Wc(EndUse):
                 consumption[start:end, j, ind_enduse, pattern_num, 1] = intensity*temperature_fraction
 
 
-        return consumption
+        return consumption, (discharge if simulate_discharge else None)
 
 @dataclass
 class WcNormal(Wc):

--- a/pysimdeum/core/end_use.py
+++ b/pysimdeum/core/end_use.py
@@ -224,7 +224,7 @@ class BathroomTap(EndUse):
             discharge_flow_rate = intensity
 
         while remaining_water > 0:
-            discharge_duration = min(remaining_water / discharge_flow_rate, duration)
+            discharge_duration = remaining_water / discharge_flow_rate
             end = int(start + discharge_duration)            
             discharge[start:end, j, ind_enduse, pattern_num, 0] = discharge_flow_rate
             remaining_water -= discharge_flow_rate * discharge_duration

--- a/pysimdeum/data/NL/end_uses/BathroomTap.toml
+++ b/pysimdeum/data/NL/end_uses/BathroomTap.toml
@@ -26,8 +26,8 @@ average = 4.1  # average frequency of end-use
 
         [subtype.washing_shaving.discharge_intensity]
             distribution = 'Uniform'
-            low = 0.067
-            high = 0.133
+            low = 0
+            high = 0.02
 
     [subtype.brushing_teeth]
         penetration = 66.6
@@ -44,5 +44,5 @@ average = 4.1  # average frequency of end-use
 
         [subtype.brushing_teeth.discharge_intensity]
             distribution = 'Uniform'
-            low = 0.067
-            high = 0.133
+            low = 0
+            high = 0.02

--- a/pysimdeum/data/NL/end_uses/BathroomTap.toml
+++ b/pysimdeum/data/NL/end_uses/BathroomTap.toml
@@ -24,6 +24,11 @@ average = 4.1  # average frequency of end-use
             low = 0.0
             high = 0.083
 
+        [subtype.washing_shaving.discharge_intensity]
+            distribution = 'Uniform'
+            low = 0.067
+            high = 0.133
+
     [subtype.brushing_teeth]
         penetration = 66.6
         temperature = 10
@@ -36,3 +41,8 @@ average = 4.1  # average frequency of end-use
             distribution = 'Uniform'
             low = 0.0
             high = 0.083
+
+        [subtype.brushing_teeth.discharge_intensity]
+            distribution = 'Uniform'
+            low = 0.067
+            high = 0.133


### PR DESCRIPTION
A first step at implementing discharge flows. Requirements for discharge calculations and discharge object are:
- Linked to consumption simulations (i.e. appliance and user specific for a simulated consumption pattern)
- Discharge isn't always required so should be `optional`
- Users may be interested in only the discharge data -> separate 'consumption' and 'discharge' arrays (with discharge replicating the consumption array structure)
- Some appliances have very simple discharge behaviour where discharge begins at the same time as consumption (e.g. `BathroomTap`), whereas others require an offset due to usage time such as `Bathtub`. Finally, appliances such as `Dishwasher` and `WashingMachine` may have a more nuanced discharge pattern.
- Discharge flow rates should be able to be inputted by the user in a similar way to consumption flow rates.

This PR provides a first pass at initialising a `discharge` DataArray in the same structure as the `consumption` array. The calculation is only applied to a `BathroomTap`. A couple of key things:
- Appliance discharge flow rate is sampled from a uniform distribution (low and high defined in `BathroomTap.toml`)
- In the simple case here, a BathroomTap with a higher discharge flow rate than consumption flow rate needs the `discharge_flow_rate` to be limited to consumption (`intensity`)
- If the sampled `discharge_flow_rate` is less than consumption `intensity` then this will result in an elongated discharge time for that event.

An example of how to run this and view some plots:
```
house = pysimdeum.built_house(house_type='one_person')
consumption, discharge = house.simulate(num_patterns=1, simulate_discharge=True)

consumption.sum(["user"]).sel(enduse="BathroomTap").sel(flowtypes="totalflow").plot()
discharge.sum(["user"]).sel(enduse="BathroomTap").sel(dischargetypes="discharge").plot()
```
Example plots using significantly lower discharge flow rates for a `BathroomTap` than consumption `intensity`. Demonstrates water being held back with an elongated discharge event to a matching consumption event.

![cons](https://github.com/user-attachments/assets/517d66d5-4b97-4abe-ad98-00ff83dc1a03)
![discharge](https://github.com/user-attachments/assets/c20542d4-f38a-4527-a1bf-5a3e4d5fc277)
