### PR TITLE
WC and Bathtub discharge simulations

### DIFF
--- a/pysimdeum/core/end_use.py
+++ b/pysimdeum/core/end_use.py
@@ -152,6 +152,32 @@ class Bathtub(EndUse):
         # independent of subtype
         return self.statistics['temperature']
 
+    def calculate_discharge(self, discharge, end, duration, intensity, temperature_fraction, j, ind_enduse, pattern_num):
+        remaining_water = intensity * duration
+
+        # Sample a usage_delay from a uniform distribution
+        usage_delay_stats = self.statistics['usage_delay']
+        usage_delay = np.random.uniform(usage_delay_stats['low'], usage_delay_stats['high']) * 60
+
+        start = int(end + usage_delay)
+
+        # Sample a value from the discharge_intensity distribution
+        discharge_intensity_stats = self.statistics['discharge_intensity']
+        dist = getattr(np.random, discharge_intensity_stats['distribution'].lower())
+        low = discharge_intensity_stats['low']
+        high = discharge_intensity_stats['high']
+        discharge_flow_rate = dist(low=low, high=high)
+
+        while remaining_water > 0:
+            discharge_duration = remaining_water / discharge_flow_rate
+            end = int(start + discharge_duration)
+            discharge[start:end, j, ind_enduse, pattern_num, 0] = discharge_flow_rate
+            remaining_water -= discharge_flow_rate * discharge_duration
+            start = end
+
+        return discharge
+
+
     def simulate(self, consumption, discharge=None, users=None, ind_enduse=None, pattern_num=1, day_num=0, simulate_discharge=False):
 
         prob_usage = self.usage_probability().values
@@ -172,6 +198,11 @@ class Bathtub(EndUse):
                 consumption[start:end, j, ind_enduse, pattern_num, 0] = intensity
                 temperature_fraction = (temperature - self.cold_water_temp)/(self.hot_water_temp - self.cold_water_temp)
                 consumption[start:end, j, ind_enduse, pattern_num, 1] = intensity*temperature_fraction
+
+                if simulate_discharge:
+                    if discharge is None:
+                        raise ValueError("Discharge array is None. It must be initialized before being passed to the simulate function.")
+                    discharge = self.calculate_discharge(discharge, end, duration, intensity, temperature_fraction, j, ind_enduse, pattern_num)
 
         return consumption, (discharge if simulate_discharge else None)
 
@@ -611,6 +642,23 @@ class Wc(EndUse):
         return duration, intensity, temperature
 
 
+    def calculate_discharge(self, discharge, start, duration, intensity, temperature_fraction, j, ind_enduse, pattern_num):
+        incoming_water = intensity * duration
+        end = int(start)
+
+        # Sample a value from the discharge_intensity distribution
+        discharge_flow_rate = self.statistics['discharge_intensity']
+
+        while incoming_water > 0:
+            discharge_duration = incoming_water / discharge_flow_rate
+            start = int(end - discharge_duration)
+            discharge[start:end, j, ind_enduse, pattern_num, 0] = discharge_flow_rate
+            incoming_water -= discharge_flow_rate * discharge_duration
+            end = start
+
+        return discharge
+
+
     def simulate(self, consumption, discharge=None, users=None, ind_enduse=None, pattern_num=1, day_num=0, simulate_discharge=False):
 
         prob_usage = self.usage_probability().values
@@ -631,6 +679,10 @@ class Wc(EndUse):
                 temperature_fraction = (temperature - self.cold_water_temp)/(self.hot_water_temp - self.cold_water_temp)
                 consumption[start:end, j, ind_enduse, pattern_num, 1] = intensity*temperature_fraction
 
+                if simulate_discharge:
+                    if discharge is None:
+                        raise ValueError("Discharge array is None. It must be initialized before being passed to the simulate function.")
+                    discharge = self.calculate_discharge(discharge, start, duration, intensity, temperature_fraction, j, ind_enduse, pattern_num)
 
         return consumption, (discharge if simulate_discharge else None)
 

--- a/pysimdeum/data/NL/end_uses/Bathtub.toml
+++ b/pysimdeum/data/NL/end_uses/Bathtub.toml
@@ -5,7 +5,7 @@ temperature = 40 # temperature of used-water [%]
 offset = 0  # offset defines the time where a second use of the end-use is blocked
 size = 120  # size of bathtub filling [L], but this parameter is not used
 duration = '10 Minutes'  # duration of filling a bathtub depends on the size and the intensity of the filling
-intensity = 0.2  # fixed intensity for bathtub filling corresponds to the maximum water flow at full tap opening [L/s]
+intensity = 0.2  # fixed intensity for bathtub filling corresponds to the maximum water flow at full tap opening [L/s
 
 [penetration]  # penetraton rate of houses with bathtubes [%] depennds on the number of people living in a house
     1 = 28
@@ -27,3 +27,12 @@ intensity = 0.2  # fixed intensity for bathtub filling corresponds to the maximu
         senior = 0.028571
         total = 0.042857
 
+[discharge_intensity]
+    distribution = 'Uniform'
+    low = 0.4
+    high = 0.6
+
+[usage_delay] # minutes
+    distribution = 'Uniform'
+    low = 20
+    high = 40

--- a/pysimdeum/data/NL/end_uses/Wc.toml
+++ b/pysimdeum/data/NL/end_uses/Wc.toml
@@ -4,8 +4,9 @@ penetration = 100  # penetraton rate of houses with wc [%]
 # pattern_generator = ''  # if a pattern exists, otherwise this field is an empty string
 offset = 0  # offset defines the time where a second use of the end-use is blocked
 temperature = 10  # temperature of used-water [%]
-prob_flush_interuption = 70  # probability if a water savings option of a toilett is installed that it will be used [%]
+prob_flush_interuption = 70  # probability if a water savings option of a toilet is installed that it will be used [%]
 intensity = 0.042  # fixed intensity for toilet flush corresponds to the pipesize to fill the cistern [L/s]
+discharge_intensity = 1.2
 
 [frequency]
     distribution = 'Poisson'  # type of distribution from where the frequency of the  end-use will be drawn


### PR DESCRIPTION
Discharge patterns for `WC` and `Bathtub` are added. This makes use of the discharge object added in PR https://github.com/KWR-Water/pysimdeum/pull/39. The added 'calculate_discharge' functions added for each appliance class operates in largely the same way as for the BathroomTap (https://github.com/KWR-Water/pysimdeum/pull/39). There are two main distinctions:
- The discharge of `WC` (representing a flush) takes place before consumption/intake of water. Therefore the start of the consumption is used as the end of the discharge flow.
- Before being discharged, a `BathTub` will be in use for a period of time after being filled up. A `usage_delay` range is added to `bathtub.toml` so that a usage time can be sampled from the distribution.

Apart from these two differences, the discharge patterns work in the same way as the `BathroomTap` - a simple discharge flow of consistent discharge flow rate.

### Bathtub consumption
![90bf9d33-83d4-4205-8aa3-8d2548091099](https://github.com/user-attachments/assets/47a4cf63-3b4d-4028-a99d-8e6d087f3eb2)
### Bathtub discharge
![f95e048d-6d81-408e-9306-bc220550001e](https://github.com/user-attachments/assets/1635ed23-f582-48fd-a825-277652e051a2)

### WC consumption
![eedc3aae-1c18-4f34-b054-bb25bc1f7f4c](https://github.com/user-attachments/assets/c990ea78-f3fb-42b8-977a-a866208e3857)
### WC discharge
![6de5596a-8932-48b2-8530-1d8d48673698](https://github.com/user-attachments/assets/17b3cd45-824a-4961-b392-a06c3ef2c94a)