### PR TITLE
Kitchen Tap discharge

### DIFF
--- a/pysimdeum/core/end_use.py
+++ b/pysimdeum/core/end_use.py
@@ -394,8 +394,6 @@ class KitchenTap(EndUse):
         while remaining_water > 0:
             discharge_duration = remaining_water / discharge_flow_rate
             end = int(start + discharge_duration)
-            print("subtype: ", self.subtype)
-            print("start:", start)
             # check if subtype = consumption (drinking), if so the discharge flow rate is set to 0
             if self.subtype == 'consumption':
                 discharge[start:end, j, ind_enduse, pattern_num, 0] = 0

--- a/pysimdeum/core/end_use.py
+++ b/pysimdeum/core/end_use.py
@@ -343,10 +343,10 @@ class KitchenTap(EndUse):
 
     def fct_duration_intensity_temperature(self):
 
-        subtype = chooser(self.statistics['subtype'], 'penetration')
+        self.subtype = chooser(self.statistics['subtype'], 'penetration')
 
-        d_stats = self.statistics['subtype'][subtype]['duration']
-        i_stats = self.statistics['subtype'][subtype]['intensity']
+        d_stats = self.statistics['subtype'][self.subtype]['duration']
+        i_stats = self.statistics['subtype'][self.subtype]['intensity']
 
         dist = getattr(np.random, d_stats['distribution'].lower())
         mean = np.log(pd.Timedelta(d_stats['average']).total_seconds()) - 0.5
@@ -358,7 +358,7 @@ class KitchenTap(EndUse):
         high = i_stats['high']
 
         intensity = dist(low=low, high=high)
-        temperature = self.statistics['subtype'][subtype]['temperature']
+        temperature = self.statistics['subtype'][self.subtype]['temperature']
 
         return duration, intensity, temperature
     

--- a/pysimdeum/core/end_use.py
+++ b/pysimdeum/core/end_use.py
@@ -377,9 +377,21 @@ class KitchenTap(EndUse):
         if discharge_flow_rate > intensity:
             discharge_flow_rate = intensity
 
+        # Check if the tap is turned off before the end of the duration, if so, update the start time
+        if discharge[start, j, ind_enduse, pattern_num, 0] > 0:
+            next_zero_timestamp = start + 1
+            while next_zero_timestamp < len(discharge) and discharge[next_zero_timestamp, j, ind_enduse, pattern_num, 0] > 0: 
+                next_zero_timestamp += 1
+
+            if next_zero_timestamp < len(discharge):
+                start = next_zero_timestamp
+            else:
+                print("?")
+                return discharge
+
         while remaining_water > 0:
             discharge_duration = remaining_water / discharge_flow_rate
-            end = int(start + discharge_duration)            
+            end = int(start + discharge_duration)         
             discharge[start:end, j, ind_enduse, pattern_num, 0] = discharge_flow_rate
             remaining_water -= discharge_flow_rate * discharge_duration
             start = end
@@ -417,7 +429,6 @@ class KitchenTap(EndUse):
                 if discharge is None:
                     raise ValueError("Discharge array is None. It must be initialized before being passed to the simulate function.")
                 discharge = self.calculate_discharge(discharge, start, duration, intensity, temperature_fraction, j, ind_enduse, pattern_num)
-
 
         return consumption, (discharge if simulate_discharge else None)
 

--- a/pysimdeum/core/end_use.py
+++ b/pysimdeum/core/end_use.py
@@ -371,7 +371,9 @@ class KitchenTap(EndUse):
         dist = getattr(np.random, discharge_intensity_stats['distribution'].lower())
         low = discharge_intensity_stats['low']
         high = discharge_intensity_stats['high']
-        discharge_flow_rate = dist(low=low, high=high)
+        discharge_flow_rate = 0
+        while discharge_flow_rate == 0: #ensure the discharge is not zero
+            discharge_flow_rate = dist(low=low, high=high)
 
         # limit discharge_flow_rate to the intensity of the tap if there is not enough water to discharge
         if discharge_flow_rate > intensity:
@@ -386,13 +388,20 @@ class KitchenTap(EndUse):
             if next_zero_timestamp < len(discharge):
                 start = next_zero_timestamp
             else:
-                print("?")
+                print("Warning: No zero value found in discharge array.")
                 return discharge
 
         while remaining_water > 0:
             discharge_duration = remaining_water / discharge_flow_rate
-            end = int(start + discharge_duration)         
-            discharge[start:end, j, ind_enduse, pattern_num, 0] = discharge_flow_rate
+            end = int(start + discharge_duration)
+            print("subtype: ", self.subtype)
+            print("start:", start)
+            # check if subtype = consumption (drinking), if so the discharge flow rate is set to 0
+            if self.subtype == 'consumption':
+                discharge[start:end, j, ind_enduse, pattern_num, 0] = 0
+            else:
+                discharge[start:end, j, ind_enduse, pattern_num, 0] = discharge_flow_rate         
+            #discharge[start:end, j, ind_enduse, pattern_num, 0] = discharge_flow_rate
             remaining_water -= discharge_flow_rate * discharge_duration
             start = end
 

--- a/pysimdeum/data/NL/end_uses/KitchenTap.toml
+++ b/pysimdeum/data/NL/end_uses/KitchenTap.toml
@@ -22,7 +22,6 @@ distribution = 'Negative_binomial'
     5 = 9.1
 
 [subtype]
-
     [subtype.consumption]
 
         penetration = 37.5

--- a/pysimdeum/data/NL/end_uses/KitchenTap.toml
+++ b/pysimdeum/data/NL/end_uses/KitchenTap.toml
@@ -37,6 +37,11 @@ distribution = 'Negative_binomial'
             low = 0.0
             high = 0.167
 
+        [subtype.consumption.discharge_intensity]
+            distribution = 'Uniform'
+            low = 0.0
+            high = 0.02
+
     [subtype.dishes]
         penetration = 25
         temperature = 55
@@ -49,6 +54,11 @@ distribution = 'Negative_binomial'
             distribution = 'Uniform'
             low = 0.0
             high = 0.25
+
+        [subtype.dishes.discharge_intensity]
+            distribution = 'Uniform'
+            low = 0.0
+            high = 0.02
 
     [subtype.washing_hands]
         penetration = 25
@@ -63,6 +73,11 @@ distribution = 'Negative_binomial'
             low = 0.0
             high = 0.167
 
+        [subtype.washing_hands.discharge_intensity]
+            distribution = 'Uniform'
+            low = 0.0
+            high = 0.02
+
     [subtype.other]
         penetration = 12.5
         temperature = 10
@@ -75,3 +90,8 @@ distribution = 'Negative_binomial'
             distribution = 'Uniform'
             low = 0.0
             high = 0.167
+
+        [subtype.other.discharge_intensity]
+            distribution = 'Uniform'
+            low = 0.0
+            high = 0.02


### PR DESCRIPTION
Added the discharge patterns for KitchenTap. It uses the discharge object added in PR #39 . Works exactly the same as the BathroomTap, using a simple discharge flow of consistent discharge flow rate.

**Consumption**
![image](https://github.com/user-attachments/assets/b130d0c6-ce52-45ce-9f02-c4c14b9caa53)

**Discharge**
![image](https://github.com/user-attachments/assets/8edb7457-eb0d-4edd-8075-1f9e8df28c84)

