### PR TITLE
`WashingMachine` & `Dishwasher` discharge pattern

### DIFF
--- a/pysimdeum/core/end_use.py
+++ b/pysimdeum/core/end_use.py
@@ -318,7 +318,7 @@ class Dishwasher(EndUse):
 
             end_of_day = 24 * 60 * 60 * (day_num + 1)
             if end > end_of_day:
-                consumption = handle_spillover_consumption(consumption, pattern, start, end, j, ind_enduse, pattern_num, end_of_day)
+                consumption = handle_spillover_consumption(consumption, pattern, start, end, j, ind_enduse, pattern_num, end_of_day, self.name)
             else:
                 difference = end - start
                 consumption[start:end, j, ind_enduse, pattern_num, 0] = pattern[:difference]
@@ -599,7 +599,7 @@ class WashingMachine(EndUse):
 
             end_of_day = 24 * 60 * 60 * (day_num + 1)
             if end > end_of_day:
-                consumption = handle_spillover_consumption(consumption, pattern, start, end, j, ind_enduse, pattern_num, end_of_day)
+                consumption = handle_spillover_consumption(consumption, pattern, start, end, j, ind_enduse, pattern_num, end_of_day, "WashingMachine")
             else:
                 difference = end - start
                 consumption[start:end, j, ind_enduse, pattern_num, 0] = pattern[:difference]

--- a/pysimdeum/core/end_use.py
+++ b/pysimdeum/core/end_use.py
@@ -2,7 +2,7 @@ import copy
 import pandas as pd
 import numpy as np
 from dataclasses import dataclass, field
-from pysimdeum.core.utils import chooser, duration_decorator, normalize, to_timedelta, handle_spillover_consumption, handle_discharge_spillover
+from pysimdeum.core.utils import chooser, duration_decorator, normalize, to_timedelta, handle_spillover_consumption, handle_discharge_spillover, sample_start_time
 from pysimdeum.core.statistics import Statistics	
 
 
@@ -310,11 +310,13 @@ class Dishwasher(EndUse):
         pattern = self.fct_duration_pattern().values
         duration = len(pattern)
 
-        for i in range(freq):
+        previous_events = []
 
-            u = np.random.random()
-            start = np.argmin(np.abs(np.cumsum(prob_joint) - u)) + int(pd.to_timedelta('1 day').total_seconds())*day_num
-            end = start + duration
+        for i in range(freq):
+            start, end = sample_start_time(prob_joint, day_num, duration, previous_events)
+
+            # add event times to list of previous events
+            previous_events.append((start, end))
 
             end_of_day = 24 * 60 * 60 * (day_num + 1)
             if end > end_of_day:
@@ -591,11 +593,13 @@ class WashingMachine(EndUse):
         pattern = self.fct_duration_pattern()
         duration = len(pattern)
 
-        for i in range(freq):
+        previous_events = []
 
-            u = np.random.random()
-            start = np.argmin(np.abs(np.cumsum(prob_joint) - u)) + int(pd.to_timedelta('1 day').total_seconds())*day_num
-            end = start + duration
+        for i in range(freq):
+            start, end = sample_start_time(prob_joint, day_num, duration, previous_events)
+            
+            # add event times to list of previous events
+            previous_events.append((start, end))
 
             end_of_day = 24 * 60 * 60 * (day_num + 1)
             if end > end_of_day:

--- a/pysimdeum/core/end_use.py
+++ b/pysimdeum/core/end_use.py
@@ -538,6 +538,15 @@ class WashingMachine(EndUse):
         pattern = self.statistics['enduse_pattern']
         # duration = pattern.index[-1] - pattern.index[0]
         return pattern
+    
+    def calculate_discharge(self, discharge, start, pattern, j, ind_enduse, pattern_num):
+        discharge_pattern = self.statistics['discharge_pattern']
+
+        for time in discharge_pattern[discharge_pattern > 0].index:
+            discharge_time  = start + int(time.total_seconds())
+            discharge[discharge_time, j, ind_enduse, pattern_num, 0] = discharge_pattern[time]
+
+        return discharge
 
     def simulate(self, consumption, discharge=None, users=None, ind_enduse=None, pattern_num=1, day_num=0, simulate_discharge=False):
 
@@ -571,6 +580,11 @@ class WashingMachine(EndUse):
             difference = end - start
             consumption[start:end, j, ind_enduse, pattern_num, 0] = pattern[:difference]       
             consumption[start:end, j, ind_enduse, pattern_num, 1] = 0
+
+            if simulate_discharge:
+                if discharge is None:
+                    raise ValueError("Discharge array is None. It must be initialized before being passed to the simulate function.")
+                discharge = self.calculate_discharge(discharge, start, pattern, j, ind_enduse, pattern_num)
 
         return consumption, (discharge if simulate_discharge else None)
 

--- a/pysimdeum/core/statistics.py
+++ b/pysimdeum/core/statistics.py
@@ -2,7 +2,7 @@ import os
 import toml
 from dataclasses import dataclass, field
 from pysimdeum.data.NL.end_uses.pattern.pat_dishwasher import dishwasher_daily_pattern, \
-    dishwasher_enduse_pattern
+    dishwasher_enduse_pattern, dishwasher_discharge_pattern
 from pysimdeum.data.NL.end_uses.pattern.pat_ktap import ktap_daily_pattern
 from pysimdeum.data.NL.end_uses.pattern.pat_washing_machine import washingmachine_daily_pattern, \
     washingmachine_enduse_pattern, washingmachine_discharge_pattern
@@ -57,6 +57,7 @@ class Statistics:
         self.end_uses['WashingMachine']['discharge_pattern'] = washingmachine_discharge_pattern(self.end_uses['WashingMachine']['enduse_pattern'])
         self.end_uses['Dishwasher']['daily_pattern'] = dishwasher_daily_pattern()
         self.end_uses['Dishwasher']['enduse_pattern'] = dishwasher_enduse_pattern()
+        self.end_uses['Dishwasher']['discharge_pattern'] = dishwasher_discharge_pattern(self.end_uses['Dishwasher']['enduse_pattern'])
         self.end_uses['KitchenTap']['daily_pattern'] = ktap_daily_pattern()
 
 

--- a/pysimdeum/core/statistics.py
+++ b/pysimdeum/core/statistics.py
@@ -5,7 +5,7 @@ from pysimdeum.data.NL.end_uses.pattern.pat_dishwasher import dishwasher_daily_p
     dishwasher_enduse_pattern
 from pysimdeum.data.NL.end_uses.pattern.pat_ktap import ktap_daily_pattern
 from pysimdeum.data.NL.end_uses.pattern.pat_washing_machine import washingmachine_daily_pattern, \
-    washingmachine_enduse_pattern
+    washingmachine_enduse_pattern, washingmachine_discharge_pattern
 from pysimdeum.data import DATA_DIR
 
 @dataclass
@@ -54,6 +54,7 @@ class Statistics:
         # Pattern
         self.end_uses['WashingMachine']['daily_pattern'] = washingmachine_daily_pattern()
         self.end_uses['WashingMachine']['enduse_pattern'] = washingmachine_enduse_pattern()
+        self.end_uses['WashingMachine']['discharge_pattern'] = washingmachine_discharge_pattern(self.end_uses['WashingMachine']['enduse_pattern'])
         self.end_uses['Dishwasher']['daily_pattern'] = dishwasher_daily_pattern()
         self.end_uses['Dishwasher']['enduse_pattern'] = dishwasher_enduse_pattern()
         self.end_uses['KitchenTap']['daily_pattern'] = ktap_daily_pattern()

--- a/pysimdeum/core/user.py
+++ b/pysimdeum/core/user.py
@@ -147,7 +147,7 @@ class Presence:
             pass
 
 
-        pdf = pdf.astype('float').resample('1S').fillna('ffill')[:-1]
+        pdf = pdf.astype('float').resample('1s').fillna('ffill')[:-1]
 
         pdf /= np.sum(pdf)  # normalize
 

--- a/pysimdeum/core/utils.py
+++ b/pysimdeum/core/utils.py
@@ -100,6 +100,30 @@ def to_timedelta(time: Union[str, float, pd.Timedelta]) -> pd.Timedelta:
     return value
 
 
+def sample_start_time(prob_joint, day_num, duration, previous_events):
+    """
+    Samples a valid start time for an event, ensuring no overlap with previous events
+    and no start within duration before the last sampled start time.
+
+    Args:
+        prob_joint (numpy.ndarray): The joint probability distribution.
+        day_num (int): The current day number in the simulation.
+        duration (int): The duration of the event.
+        previous_events (list): List of tuples containing start and end times of previous events.
+
+    Returns:
+        int: The sampled start time.
+        int: The calculated end time.
+    """
+    while True:
+        u = np.random.random()
+        start = np.argmin(np.abs(np.cumsum(prob_joint) - u)) + int(pd.to_timedelta('1 day').total_seconds()) * day_num
+        end = start + duration
+
+        # Check for overlapping events or events within duration before the last sample start
+        if not any((start < event_end and start >= event_start) or (start < event_start and start >= event_start - int(duration)) for event_start, event_end in previous_events):
+            return start, end
+
 def handle_spillover_consumption(consumption, pattern, start, end, j, ind_enduse, pattern_num, end_of_day, name):
     """Handles the spillover of consumption events that extend beyond the end of the current day.
 

--- a/pysimdeum/core/utils.py
+++ b/pysimdeum/core/utils.py
@@ -100,7 +100,7 @@ def to_timedelta(time: Union[str, float, pd.Timedelta]) -> pd.Timedelta:
     return value
 
 
-def handle_spillover_consumption(consumption, pattern, start, end, j, ind_enduse, pattern_num, end_of_day):
+def handle_spillover_consumption(consumption, pattern, start, end, j, ind_enduse, pattern_num, end_of_day, name):
     """Handles the spillover of consumption events that extend beyond the end of the current day.
 
     Splits the consumption event into two parts: the part that fits within the current days and the part that spills over into the next day. The spillover part is moved to the start of the day, making an assumption that appliance had the same usage event beginning the previous day.
@@ -118,20 +118,18 @@ def handle_spillover_consumption(consumption, pattern, start, end, j, ind_enduse
     Returns:
         numpy.ndarray: The updated consumption array with the spillover consumption handled.
     """
+    print("An event for ", name, " use has spilled over to the next day. Adjusting spillover times...")
     # Part that fits within the current day
-    print("end of day", end_of_day)
     difference = end_of_day - start
-    print("difference", difference)
     consumption[start:end_of_day, j, ind_enduse, pattern_num, 0] = pattern[:difference]
     consumption[start:end_of_day, j, ind_enduse, pattern_num, 1] = 0
 
     # Part that spills over into the next day
     spillover_start = 0
     spillover_end = end - end_of_day
-    print("end", end)
-    print("spillover end", spillover_end)
     consumption[spillover_start:spillover_start + spillover_end, j, ind_enduse, pattern_num, 0] = pattern[difference:difference + spillover_end]
     consumption[spillover_start:spillover_start + spillover_end, j, ind_enduse, pattern_num, 1] = 0
+    print("Spillover adjustment complete.")
 
     return consumption
 
@@ -154,10 +152,7 @@ def handle_discharge_spillover(discharge, discharge_pattern, time, discharge_tim
     Returns:
         numpy.ndarray: The updated discharge array with the spillover discharge handled.
     """
-    print("end_of_day", end_of_day)
-    print("discharge_time", discharge_time)
     spillover_time = discharge_time - end_of_day
-    print("spillover_time", spillover_time)
     discharge[spillover_time, j, ind_enduse, pattern_num, 0] = discharge_pattern[time]
 
     return discharge

--- a/pysimdeum/data/NL/end_uses/pattern/pat_dishwasher.py
+++ b/pysimdeum/data/NL/end_uses/pattern/pat_dishwasher.py
@@ -8,7 +8,7 @@ def dishwasher_daily_pattern(x=None, resolution='1s'):
     if x is None:
         x = '70 49 33 69 30 19 9 37 80 52 52 45 53 78 34 44 38 101 489 390 170 185 240 574 70'
     data = list(map(float, x.split(' ')))
-    index = pd.timedelta_range(start='00:00:00', freq='1H', periods=len(data))
+    index = pd.timedelta_range(start='00:00:00', freq='1h', periods=len(data))
     s = pd.Series(data=data, index=index)
     s = s.resample(resolution).mean().interpolate(method='linear') # todo interpolate with cubic splines does not work
     s = s[s.index.days == s.index[0].days]

--- a/pysimdeum/data/NL/end_uses/pattern/pat_dishwasher.py
+++ b/pysimdeum/data/NL/end_uses/pattern/pat_dishwasher.py
@@ -66,7 +66,7 @@ def dishwasher_discharge_pattern(enduse_pattern, discharge_time=8, resolution='1
         discharge_rate = total_water_consumed / discharge_time
 
         # Assign the calculated flow rate to the discharge pattern
-        discharge_pattern.loc[discharge_start:discharge_end] = discharge_rate
+        discharge_pattern.loc[discharge_start:discharge_end - pd.Timedelta(seconds=1)] = discharge_rate
 
     # Account for the final phase_on section (the above just looks at gaps between phase_on sections)
     if len(phase_on_sections) > 0:
@@ -78,7 +78,7 @@ def dishwasher_discharge_pattern(enduse_pattern, discharge_time=8, resolution='1
         remaining_time = periods - int(last_end.total_seconds())
         discharge_start = last_end + pd.Timedelta(seconds=remaining_time // 3) # leave 2/3 of the time for a 'dry' cycle
         discharge_end = discharge_start + pd.Timedelta(seconds=discharge_time)
-        discharge_pattern.loc[discharge_start:discharge_end] = flow_rate
+        discharge_pattern.loc[discharge_start:discharge_end - pd.Timedelta(seconds=1)] = flow_rate
 
     return discharge_pattern
 

--- a/pysimdeum/data/NL/end_uses/pattern/pat_dishwasher.py
+++ b/pysimdeum/data/NL/end_uses/pattern/pat_dishwasher.py
@@ -32,6 +32,57 @@ def dishwasher_enduse_pattern(resolution='1s', periods=7200):
 
     return s
 
+
+def dishwasher_discharge_pattern(enduse_pattern, discharge_time=8, resolution='1s', periods=7200):
+    index = pd.timedelta_range(start='00:00:00', freq=resolution, periods=periods)
+    discharge_pattern = pd.Series(0, index=index)
+
+    # Identify the start and end of each phase_on section
+    phase_on_sections = []
+    in_phase = False
+    for i in range(len(enduse_pattern)):
+        if enduse_pattern.iloc[i] > 0 and not in_phase:
+            start = enduse_pattern.index[i]
+            in_phase = True
+        elif enduse_pattern.iloc[i] == 0 and in_phase:
+            end = enduse_pattern.index[i-1]
+            phase_on_sections.append((start, end))
+            in_phase = False
+    if in_phase:
+        end = enduse_pattern.index[-1]
+        phase_on_sections.append((start, end))
+
+    # Calculate the total water consumed for each phase_on section and distribute it as discharge
+    for i in range(1, len(phase_on_sections)):
+        prev_end = phase_on_sections[i-1][1]
+        next_start = phase_on_sections[i][0]
+        discharge_end = next_start - pd.Timedelta(seconds=10) # 10 second gap between discharge and next phase_on
+        discharge_start = discharge_end - pd.Timedelta(seconds=discharge_time) 
+
+        # Calculate the total water consumed for the phase_on section
+        total_water_consumed = enduse_pattern[phase_on_sections[i-1][0]:phase_on_sections[i-1][1]].sum()
+
+        # Calculate the flow rate based on the total water consumed and discharge time
+        discharge_rate = total_water_consumed / discharge_time
+
+        # Assign the calculated flow rate to the discharge pattern
+        discharge_pattern.loc[discharge_start:discharge_end] = discharge_rate
+
+    # Account for the final phase_on section (the above just looks at gaps between phase_on sections)
+    if len(phase_on_sections) > 0:
+        last_start, last_end = phase_on_sections[-1]
+        total_water_consumed = enduse_pattern[last_start:last_end].sum()
+        flow_rate = total_water_consumed / discharge_time
+
+        # Calculate the time from last_end to the end of the periods time
+        remaining_time = periods - int(last_end.total_seconds())
+        discharge_start = last_end + pd.Timedelta(seconds=remaining_time // 3) # leave 2/3 of the time for a 'dry' cycle
+        discharge_end = discharge_start + pd.Timedelta(seconds=discharge_time)
+        discharge_pattern.loc[discharge_start:discharge_end] = flow_rate
+
+    return discharge_pattern
+
+
 if __name__ == '__main__':
 
     pass

--- a/pysimdeum/data/NL/end_uses/pattern/pat_washing_machine.py
+++ b/pysimdeum/data/NL/end_uses/pattern/pat_washing_machine.py
@@ -7,7 +7,7 @@ def washingmachine_daily_pattern(x=None, resolution='1s'):
     if x is None:
         x = '34 24 17 43 41 57 57 212 290 338 392 325 226 222 200 175 124 106 139 185 133 165 101 147 34'
     data = list(map(float, x.split(' ')))
-    index = pd.timedelta_range(start='00:00:00', freq='1H', periods=25)
+    index = pd.timedelta_range(start='00:00:00', freq='1h', periods=25)
     s = pd.Series(data=data, index=index)
     s = s.resample(resolution).mean().interpolate(method='linear')
     s = s[s.index.days == s.index[0].days]

--- a/pysimdeum/data/NL/end_uses/pattern/pat_washing_machine.py
+++ b/pysimdeum/data/NL/end_uses/pattern/pat_washing_machine.py
@@ -30,4 +30,51 @@ def washingmachine_enduse_pattern(resolution='1s', periods=7200):
 
     return s
 
+def washingmachine_discharge_pattern(enduse_pattern, discharge_time=30, resolution='1s', periods=7200):
+    index = pd.timedelta_range(start='00:00:00', freq=resolution, periods=periods)
+    discharge_pattern = pd.Series(0, index=index)
 
+    # Identify the start and end of each phase_on section
+    phase_on_sections = []
+    in_phase = False
+    for i in range(len(enduse_pattern)):
+        if enduse_pattern.iloc[i] > 0 and not in_phase:
+            start = enduse_pattern.index[i]
+            in_phase = True
+        elif enduse_pattern.iloc[i] == 0 and in_phase:
+            end = enduse_pattern.index[i-1]
+            phase_on_sections.append((start, end))
+            in_phase = False
+    if in_phase:
+        end = enduse_pattern.index[-1]
+        phase_on_sections.append((start, end))
+
+    # Calculate the total water consumed for each phase_on section and distribute it as discharge
+    for i in range(1, len(phase_on_sections)):
+        prev_end = phase_on_sections[i-1][1]
+        next_start = phase_on_sections[i][0]
+        discharge_end = next_start - pd.Timedelta(seconds=10) # 10 second gap between discharge and next phase_on
+        discharge_start = discharge_end - pd.Timedelta(seconds=discharge_time) 
+
+        # Calculate the total water consumed for the phase_on section
+        total_water_consumed = enduse_pattern[phase_on_sections[i-1][0]:phase_on_sections[i-1][1]].sum()
+
+        # Calculate the flow rate based on the total water consumed and discharge time
+        discharge_rate = total_water_consumed / discharge_time
+
+        # Assign the calculated flow rate to the discharge pattern
+        discharge_pattern.loc[discharge_start:discharge_end] = discharge_rate
+
+    # Account for the final phase_on section (the above just looks at gaps between phase_on sections)
+    if len(phase_on_sections) > 0:
+        last_start, last_end = phase_on_sections[-1]
+        total_water_consumed = enduse_pattern[last_start:last_end].sum()
+        flow_rate = total_water_consumed / discharge_time
+
+        # Calculate the time from last_end to the end of the periods time
+        remaining_time = periods - int(last_end.total_seconds())
+        discharge_start = last_end + pd.Timedelta(seconds=remaining_time // 3) # leave 2/3 of the time for a 'spin' cycle
+        discharge_end = discharge_start + pd.Timedelta(seconds=discharge_time)
+        discharge_pattern.loc[discharge_start:discharge_end] = flow_rate
+
+    return discharge_pattern

--- a/pysimdeum/data/NL/end_uses/pattern/pat_washing_machine.py
+++ b/pysimdeum/data/NL/end_uses/pattern/pat_washing_machine.py
@@ -63,7 +63,7 @@ def washingmachine_discharge_pattern(enduse_pattern, discharge_time=30, resoluti
         discharge_rate = total_water_consumed / discharge_time
 
         # Assign the calculated flow rate to the discharge pattern
-        discharge_pattern.loc[discharge_start:discharge_end] = discharge_rate
+        discharge_pattern.loc[discharge_start:discharge_end - pd.Timedelta(seconds=1)] = discharge_rate # restrict range to not be inclusive of final timstamp as this would result in extra discharge
 
     # Account for the final phase_on section (the above just looks at gaps between phase_on sections)
     if len(phase_on_sections) > 0:
@@ -75,6 +75,6 @@ def washingmachine_discharge_pattern(enduse_pattern, discharge_time=30, resoluti
         remaining_time = periods - int(last_end.total_seconds())
         discharge_start = last_end + pd.Timedelta(seconds=remaining_time // 3) # leave 2/3 of the time for a 'spin' cycle
         discharge_end = discharge_start + pd.Timedelta(seconds=discharge_time)
-        discharge_pattern.loc[discharge_start:discharge_end] = flow_rate
+        discharge_pattern.loc[discharge_start:discharge_end - pd.Timedelta(seconds=1)] = flow_rate # restrict range to not be inclusive of final timstamp as this would result in extra discharge
 
     return discharge_pattern


### PR DESCRIPTION
Adds discharge pattern for the `WashingMachine` appliance. As per the design for simulating `consumption` of this appliance, it requires a departure from the methods applied for other simple appliances like the `BathroomTap` and `Bathtub`. The key addition to this PR is the `washingmachine_discharge_pattern` function implemented with `pat_washing_machine.py`.

This does a few things:
- Identifies `phase_on` cycles (i.e. consumption phases where washing machine is drawing water)
- In between `phase_on` cycles adds a discharge phase that ends `10` seconds before the next `phase_on`
- Adds in a final discharge phase after the last `phase_on` cycle that starts at 1/3 of remaining operating time, to leave ~2/3 (- discharge time) of the remaining time as a spin cycle)

In the plot below you will notice two different discharge flow rates for the same event. This is as i've opted for a fixed discharge_time for each drain cycle. The first `phase_on` cycle draws more water than the following `phase_on` cycles so results in a higher discharge flow rate. Both the lower and higher discharge flow rates sit within the acceptable range for home washing machines.

### Consumption
![b05dfa31-0341-4769-8827-04692fe54ba7](https://github.com/user-attachments/assets/42f5f04d-199c-44c4-a8ef-64af8ac27e7b)
### Discharge
![f82fb88c-63c4-49f6-b7d3-1b9bdc588149](https://github.com/user-attachments/assets/4a153043-531b-4569-9522-22cf3cfebbbf)

I think the way the `WashingMachine` `enduse_pattern` and now `discharge_pattern` is defined could be improved. Currently they are stored in functions within `pat_washing_machine.py` stored within the`data/NL` folder. Cycle times are hardcoded into this. These functions should be moved into the `utils.py` script as helper functions and the data on cycle times etc. moved into the `WashingMachine.toml`. https://github.com/KWR-Water/pysimdeum/issues/47