### PR TITLE
Spillover feature for `WashingMachine` and `Dishwasher`

### DIFF
--- a/pysimdeum/core/end_use.py
+++ b/pysimdeum/core/end_use.py
@@ -356,7 +356,6 @@ class Dishwasher(EndUse):
                 consumption = handle_spillover_consumption(consumption, pattern, start, end, j, ind_enduse, pattern_num, end_of_day, self.name, total_days)
             elif ((day_num + 1) == total_days) and (end > end_of_day):
                 difference = end_of_day - start
-                print(difference)
                 consumption[start:end_of_day, j, ind_enduse, pattern_num, 0] = pattern[:difference]
                 consumption[start:end_of_day, j, ind_enduse, pattern_num, 1] = 0
             else:
@@ -646,7 +645,6 @@ class WashingMachine(EndUse):
                 consumption = handle_spillover_consumption(consumption, pattern, start, end, j, ind_enduse, pattern_num, end_of_day, "WashingMachine", total_days)
             elif ((day_num + 1) == total_days) and (end > end_of_day):
                 difference = end_of_day - start
-                print(difference)
                 consumption[start:end_of_day, j, ind_enduse, pattern_num, 0] = pattern[:difference]
                 consumption[start:end_of_day, j, ind_enduse, pattern_num, 1] = 0
             else:

--- a/pysimdeum/core/house.py
+++ b/pysimdeum/core/house.py
@@ -267,7 +267,7 @@ class House(Property):
                                         dims=['time', 'user', 'enduse'])
         return self.consumption
 
-    def simulate(self, date=None, duration='1 day', num_patterns=1, simulate_discharge=False):
+    def simulate(self, date=None, duration='1 day', num_patterns=1, simulate_discharge=False, spillover=False):
 
         if date is None:
             date = datetime.now().date()
@@ -296,9 +296,9 @@ class House(Property):
             for k, appliance in enumerate(self.appliances):
                 for day in range(0, number_of_days, 1):
                     if simulate_discharge:
-                        consumption, discharge = appliance.simulate(consumption, discharge, users=self.users, ind_enduse=k, pattern_num=num, day_num=day, simulate_discharge=simulate_discharge)
+                        consumption, discharge = appliance.simulate(consumption, discharge, users=self.users, ind_enduse=k, pattern_num=num, day_num=day, total_days=number_of_days, simulate_discharge=simulate_discharge, spillover=spillover)
                     else:
-                        consumption, _ = appliance.simulate(consumption, None, users=self.users, ind_enduse=k, pattern_num=num, day_num=day, simulate_discharge=simulate_discharge)
+                        consumption, _ = appliance.simulate(consumption, None, users=self.users, ind_enduse=k, pattern_num=num, day_num=day, total_days=number_of_days, simulate_discharge=simulate_discharge, spillover=spillover)
 
         if simulate_discharge:
             self.consumption = xr.DataArray(data=consumption, coords=[time, users, enduse, patterns, flowtype], dims=['time', 'user', 'enduse', 'patterns', 'flowtypes'])


### PR DESCRIPTION
Closes #57 

This introduces logic for handling `consumption` and `discharge` simulations that extend into a different day (past midnight).

User can apply this by running:
```
consumption, discharge = house.simulate(duration='3 day', num_patterns=1, simulate_discharge=True, spillover=True)
```

Key points here are that:
- `spillover` is an optional feature. By default, the event will just be cropped out if it extends past the end of simulation.
- When `spillover` is `True` and a single day is simulated, the event extending past midnight will spill back into the start of the same day.
- When `spillover` is True and multiple days are simulated, if an event extends past midnight that is not the final day in the simulation (e.g. day 2 of 4), it will just carry onto the next day as normal. However, if the event occurs on the final day in the simulation and extends past midnight it will spill back into the start of the simulation on the first day.

The value of the `spillover` feature is that if the user requires, it preserves antecedent conditions for the given time period (number of days) simulated.

Note that this is currently only applied to the `WashingMachine` and `Dishwasher` appliances.

### Two day consumption (past midnight on day 1)
![twodayconsumption](https://github.com/user-attachments/assets/58599b66-d686-4191-8c8d-1003afdd9b1b)

### Two day discharge (past midnight on day 1)
![twodaydischarge](https://github.com/user-attachments/assets/62e1cb17-db6c-4ef6-9315-056e2518b81e)

### Three day consumption (past midnight on final day)
![threedayconsumption](https://github.com/user-attachments/assets/cb3aeb6a-e525-4f91-8e62-da717e1bb636)

### Three day discharge (past midnight on final day)
![threedaydischarge](https://github.com/user-attachments/assets/d214f4c6-ccf5-40cc-97f4-056d26543652)