### PR TITLE
Added discharge for the Shower

### DIFF
--- a/pysimdeum/core/utils.py
+++ b/pysimdeum/core/utils.py
@@ -205,7 +205,6 @@ def offset_simultaneous_discharge(discharge, start, j, ind_enduse, pattern_num):
         if next_zero_timestamp < len(discharge):
             return next_zero_timestamp # return update start time
         else:
-            print("Warning: No zero value found in discharge array.")
             return discharge
 
     return start #return original start

--- a/pysimdeum/core/utils.py
+++ b/pysimdeum/core/utils.py
@@ -181,6 +181,35 @@ def handle_discharge_spillover(discharge, discharge_pattern, time, discharge_tim
 
     return discharge
 
+def offset_simultaneous_discharge(discharge, start, j, ind_enduse, pattern_num):
+    """Checks if the tap is turned off before the end of the duration. If so, updates the start time to the next zero value in the discharge array.
+
+    This function shifts the discharge start time to the next available zero value in the discharge array.
+
+    Args:
+        discharge (numpy.ndarray): The array representing the discharge data.
+        start (int): The start time of the discharge event in seconds from the beginning of the day.
+        j (int): The index of the user.
+        ind_enduse (int): The index of the end-use appliance.
+        pattern_num (int): The pattern number.
+
+    Returns:
+        numpy.ndarray: The updated start index or original array if no zero is found
+    """
+
+    if discharge[start, j, ind_enduse, pattern_num, 0] > 0:
+        next_zero_timestamp = start + 1
+        while next_zero_timestamp < len(discharge) and discharge[next_zero_timestamp, j, ind_enduse, pattern_num, 0] > 0: 
+            next_zero_timestamp += 1
+
+        if next_zero_timestamp < len(discharge):
+            return next_zero_timestamp # return update start time
+        else:
+            print("Warning: No zero value found in discharge array.")
+            return discharge
+
+    return start #return original start
+
 
 @dataclass
 class Base:

--- a/pysimdeum/data/NL/end_uses/Shower.toml
+++ b/pysimdeum/data/NL/end_uses/Shower.toml
@@ -34,7 +34,17 @@ pattern = 'name of pattern generator'
         penetration = 50
         intensity = 0.142  # [L/s]
 
+        [subtype.NormalShower.discharge_intensity]
+            distribution = 'Uniform'
+            low = 0.0
+            high = 0.14
+
     [subtype.FancyShower]
         # combi_heater_with_water_saving_shower_head
         penetration = 50
         intensity = 0.123  # [L/s]
+
+        [subtype.FancyShower.discharge_intensity]
+            distribution = 'Uniform'
+            low = 0.0
+            high = 0.12


### PR DESCRIPTION
Added discharge pattern for the `Shower`. Uses the same simple discharge method as with the `BathroomTap` and `KitchenTap`.

Also in this PR I've added the function `offset_simultaneous_discharge` to the utils.py script that fixes the simultaneous discharge events issue we were seeing in the taps, closing the issue #49 .

In the below plots you'll see the consumption and discharge of the shower.

Consumption:
![image](https://github.com/user-attachments/assets/c091f63d-f55c-4a6d-95cf-277e434229ab)

Discharge:
![image](https://github.com/user-attachments/assets/99aa7796-42aa-4f41-909a-42bcc6f0842d)
