### PR TITLE
clear discharge_events

### DIFF
--- a/pysimdeum/core/house.py
+++ b/pysimdeum/core/house.py
@@ -294,6 +294,10 @@ class House(Property):
         if simulate_discharge:
             dischargetype = ['greywater', 'blackwater']
             discharge = np.zeros((len(time), len(users), len(enduse), num_patterns, len(dischargetype)))
+            # Clear discharge_events for all appliances
+            for appliance in self.appliances:
+                if hasattr(appliance, 'discharge_events'):
+                    appliance.discharge_events.clear()
         else:
             discharge = None
 


### PR DESCRIPTION
Fixes a bug where resimulating discharge by calling `house.simulate(simulate_dischgarge=True)` after building a house only appends to the `discharge_events` metadata rather than clearing it.