### PR TITLE
fix: use the `offset` config parameter rather than ignoring it.

### DIFF
--- a/pysimdeum/core/end_use.py
+++ b/pysimdeum/core/end_use.py
@@ -99,19 +99,8 @@ class EndUse:
 @dataclass
 class Bathtub(EndUse):
     """Class for Bathtub end-use."""
-    #discharge_events: list = field(default_factory=list)
-
-    def __post_init__(self):
-        """Initialisation function of Bathtub end-use class.
-
-        Args:
-            name: End-use name as string.
-            **kwargs: keyword arguments for super classes.
-        """
-        super().__post_init__()
-        self.name = "Bathtub"
-        self.wastewater_type = "greywater"
-        #self.discharge_events = []
+    name: str = "Bathtub"
+    wastewater_type: str = "greywater"
 
     def fct_frequency(self, age=None):
         """Random function computing the frequency of use for the Bathtub end-use class.
@@ -227,12 +216,9 @@ class Bathtub(EndUse):
 
 @dataclass
 class BathroomTap(EndUse):
-    #discharge_events: list = field(default_factory=list)
-    def __post_init__(self):
-        super().__post_init__()
-        self.name = "BathroomTap"
-        self.wastewater_type = "greywater"
-        #self.discharge_events = []
+    """Base class for bathroom taps."""
+    name: str = "BathroomTap"
+    wastewater_type: str = "greywater"
 
     def fct_frequency(self):
 
@@ -324,13 +310,9 @@ class BathroomTap(EndUse):
 
 @dataclass
 class Dishwasher(EndUse):
-    #discharge_events: list = field(default_factory=list)
-
-    def __post_init__(self):
-        super().__post_init__()
-        self.name = "Dishwasher"
-        self.wastewater_type = "blackwater"
-        #self.discharge_events = []
+    """Base class for dishwashers."""
+    name: str = "Dishwasher"
+    wastewater_type: str = "blackwater"
 
     def fct_frequency(self, numusers=None):
 
@@ -434,13 +416,9 @@ class Dishwasher(EndUse):
 
 @dataclass
 class KitchenTap(EndUse):
-    #discharge_events: list = field(default_factory=list)
-
-    def __post_init__(self):
-        super().__post_init__()
-        self.name = "KitchenTap"
-        self.wastewater_type = "blackwater"
-        #self.discharge_events = []
+    """Base class for kitchen taps."""
+    name: str = "KitchenTap"
+    wastewater_type: str = "blackwater"
 
     def fct_frequency(self, numusers=None):
 
@@ -569,10 +547,8 @@ class KitchenTap(EndUse):
 
 @dataclass
 class OutsideTap(EndUse):
-
-    def __post_init__(self):
-        super().__post_init__()
-        self.name = "OutsideTap"
+    """Base class for outdoor water use."""
+    name: str = "OutsideTap"
 
     def fct_frequency(self):
 
@@ -637,13 +613,9 @@ class OutsideTap(EndUse):
 
 @dataclass
 class Shower(EndUse):
-    #discharge_events: list = field(default_factory=list)
-
-    def __post_init__(self):
-        super().__post_init__()
-        self.name = "Shower"
-        self.wastewater_type = "greywater"
-        #self.discharge_events = []
+    """Base class for all showers."""
+    name: str = "Shower"
+    wastewater_type: str = "greywater"
 
     def fct_frequency(self, age=None):
 
@@ -728,29 +700,23 @@ class Shower(EndUse):
         return consumption, (discharge if simulate_discharge else None)
 
 
+@dataclass
 class NormalShower(Shower):
+    """Most common shower."""
+    name: str = "NormalShower"
 
-    def __post_init__(self):
-        super().__post_init__()
-        self.name = "NormalShower"
-        self.wastewater_type = "greywater"
 
+@dataclass
 class FancyShower(Shower):
-
-    def __post_init__(self):
-        super().__post_init__()
-        self.name = "FancyShower"
-        self.wastewater_type = "greywater"
+    """Combi-heater with water-saving showerhead."""
+    name: str = "FancyShower"
 
 
+@dataclass
 class WashingMachine(EndUse):
-    #discharge_events: list = field(default_factory=list)
-
-    def __post_init__(self):
-        super().__post_init__()
-        self.name = "WashingMachine"
-        self.wastewater_type = "blackwater"
-        #self.discharge_events = []
+    """Base class for washing machines."""
+    name: str = "WashingMachine"
+    wastewater_type: str = "blackwater"
 
     def fct_frequency(self, numusers=None):
 
@@ -857,12 +823,12 @@ class WashingMachine(EndUse):
 
 @dataclass
 class Wc(EndUse):
-    #discharge_events: list = field(default_factory=list)
+    """Base class for all WC flushes."""
+    name: str = "Wc"
+    wastewater_type: str = "blackwater"
 
     def __post_init__(self):
         super().__post_init__()
-        self.name = "Wc"
-        self.wastewater_type = "blackwater"
         self.discharge_events = []
 
     def fct_frequency(self, age=None, gender=None):
@@ -953,35 +919,23 @@ class Wc(EndUse):
 
 @dataclass
 class WcNormal(Wc):
-
-    def __post_init__(self):
-        super().__post_init__()
-        self.name = 'WcNormal'
-        self.wastewater_type = "blackwater"
+    """Most common toilet flush."""
+    name: str = 'WcNormal'
 
 
 @dataclass
 class WcNormalSave(Wc):
-
-    def __post_init__(self):
-        super().__post_init__()
-        self.name = "WcNormalSave"
-        self.wastewater_type = "blackwater"
+    """Most common toilet flush with a water-saving option."""
+    name: str = "WcNormalSave"
 
 
 @dataclass
 class WcNew(Wc):
-
-    def __post_init__(self):
-        super().__post_init__()
-        self.name = "WcNew"
-        self.wastewater_type = "blackwater"
+    """Toilet flush complying with the new efficiency standards."""
+    name: str = "WcNew"
 
 
 @dataclass
 class WcNewSave(Wc):
-
-    def __post_init__(self):
-        super().__post_init__()
-        self.name = "WcNewSave"
-        self.wastewater_type = "blackwater"
+    """Toilet flush complying with the new standard and with a water-saving option."""
+    name: str = "WcNewSave"

--- a/pysimdeum/core/end_use.py
+++ b/pysimdeum/core/end_use.py
@@ -4,7 +4,7 @@ import numpy as np
 from dataclasses import dataclass, field
 from pysimdeum.utils.probability import chooser, duration_decorator, normalize, to_timedelta
 from pysimdeum.utils.patterns import handle_spillover_consumption, handle_discharge_spillover, sample_start_time, offset_simultaneous_discharge
-from pysimdeum.core.statistics import Statistics	
+from pysimdeum.core.statistics import Statistics
 
 
 #TODO: Specific EndUse __post_init__ calls can be replaced by directly using the class name instead of setting the name attributes
@@ -12,7 +12,6 @@ from pysimdeum.core.statistics import Statistics
 @dataclass
 class EndUse:
     """Base class for end-uses."""
-    
     statistics: Statistics = field(repr=False)  # ... statistic object associated with end-use
     name: str = "EndUse"  # ... name of the end-use
     cold_water_temp = 10
@@ -77,7 +76,7 @@ class EndUse:
         """Placeholder for specific intensity probability function defined in specific EndUse"""
 
         raise NotImplementedError('Intensity function is not implemented yet!')
-    
+
     def temperature(self):
         """Placeholder for specific temperature function defined in specific EndUse"""
 
@@ -91,6 +90,7 @@ class EndUse:
         temperature = self.temperature()
 
         return duration, intensity, temperature
+
 
 @dataclass
 class Bathtub(EndUse):
@@ -145,13 +145,13 @@ class Bathtub(EndUse):
         """
         # fixed intensity
         return self.statistics['intensity']
-    
+
     def temperature(self):
         """Obtain the temperature of a bath
 
         Returns:
             temperature of bath water
-        
+
         """
         # independent of subtype
         return self.statistics['temperature']
@@ -189,7 +189,6 @@ class Bathtub(EndUse):
 
         return discharge
 
-
     def simulate(self, consumption, discharge=None, users=None, ind_enduse=None, pattern_num=1, day_num=0, total_days=1, simulate_discharge=False, spillover=False):
 
         prob_usage = self.usage_probability().values
@@ -224,7 +223,6 @@ class Bathtub(EndUse):
 @dataclass
 class BathroomTap(EndUse):
     #discharge_events: list = field(default_factory=list)
-    
     def __post_init__(self):
         self.name = "BathroomTap"
         self.wastewater_type = "greywater"
@@ -255,7 +253,7 @@ class BathroomTap(EndUse):
         intensity = dist(low=low, high=high)
         temperature = self.statistics['subtype'][self.subtype]['temperature']
         return duration, intensity, temperature
-    
+
     def calculate_discharge(self, discharge, start, duration, intensity, temperature_fraction, j, ind_enduse, pattern_num, spillover=False):
         remaining_water = intensity * duration
         start = int(start)
@@ -272,7 +270,6 @@ class BathroomTap(EndUse):
             discharge_flow_rate = intensity
 
         start = offset_simultaneous_discharge(discharge, start, j, ind_enduse, pattern_num, spillover=spillover)
-      
         self.discharge_events.append({
             'enduse': self.name,
             'usage': self.subtype, # subtypes are inherited from chooser(toml)
@@ -290,10 +287,8 @@ class BathroomTap(EndUse):
 
         return discharge
 
-
     def simulate(self, consumption, discharge, users=None, ind_enduse=None, pattern_num=1, day_num=0, total_days=1, simulate_discharge=False, spillover=False):
         prob_usage = self.usage_probability().values
-        
         previous_events = []
 
         for j, user in enumerate(users):
@@ -320,6 +315,7 @@ class BathroomTap(EndUse):
 
         return consumption, (discharge if simulate_discharge else None)
 
+
 @dataclass
 class Dishwasher(EndUse):
     #discharge_events: list = field(default_factory=list)
@@ -341,10 +337,9 @@ class Dishwasher(EndUse):
     def fct_duration_pattern(self, start=None):
         pattern = self.statistics['enduse_pattern']
         return pattern
-    
+
     def calculate_discharge(self, discharge, start, j, ind_enduse, pattern_num, day_num, end_of_day, total_days, spillover=False):
         discharge_pattern = self.statistics['discharge_pattern']
-        
         cycle_times = []
 
         for time in discharge_pattern[discharge_pattern > 0].index:
@@ -372,7 +367,7 @@ class Dishwasher(EndUse):
             discharge_temperatures = dist(low=low, high=high, size=len(cycle_times)).tolist()
         else:
             raise ValueError("Discharge temperature type not implemented.")
-        
+
         self.discharge_events.append({
             'enduse': self.name,
             'usage': self.name, # no subtypes currently
@@ -429,6 +424,7 @@ class Dishwasher(EndUse):
 
         return consumption, (discharge if simulate_discharge else None)
 
+
 @dataclass
 class KitchenTap(EndUse):
     #discharge_events: list = field(default_factory=list)
@@ -481,7 +477,7 @@ class KitchenTap(EndUse):
         temperature = self.statistics['subtype'][self.subtype]['temperature']
 
         return duration, intensity, temperature
-    
+
     def calculate_discharge(self, discharge, start, duration, intensity, temperature_fraction, j, ind_enduse, pattern_num, usage, spillover=False):
         remaining_water = intensity * duration
         start = int(start)
@@ -547,9 +543,7 @@ class KitchenTap(EndUse):
 
             # assign usage type (based on subtype)
             usage = self.subtype
-            
             prob_joint = normalize(prob_user * prob_usage)  # ToDo: Check if joint probability can be computed outside of for loop for all functions
-            
             start, end = sample_start_time(prob_joint, day_num, duration, previous_events)
             previous_events.append((start, end))
 
@@ -563,6 +557,7 @@ class KitchenTap(EndUse):
                 discharge = self.calculate_discharge(discharge, start, duration, intensity, temperature_fraction, j, ind_enduse, pattern_num, usage, spillover=spillover)
 
         return consumption, (discharge if simulate_discharge else None)
+
 
 @dataclass
 class OutsideTap(EndUse):
@@ -621,7 +616,6 @@ class OutsideTap(EndUse):
             duration, intensity, temperature = self.fct_duration_intensity_temperature()
 
             prob_joint = normalize(prob_user * prob_usage)
-            
             start, end = sample_start_time(prob_joint, day_num, duration, previous_events)
             previous_events.append((start, end))
 
@@ -630,6 +624,7 @@ class OutsideTap(EndUse):
             consumption[start:end, j, ind_enduse, pattern_num, 1] = intensity*temperature_fraction
 
         return consumption, (discharge if simulate_discharge else None)
+
 
 @dataclass
 class Shower(EndUse):
@@ -663,7 +658,7 @@ class Shower(EndUse):
         temperature = self.statistics['temperature']
 
         return duration, intensity, temperature
-    
+
     def calculate_discharge(self, discharge, start, duration, intensity, temperature_fraction, j, ind_enduse, pattern_num, spillover=False):
         remaining_water = intensity * duration
 
@@ -735,7 +730,7 @@ class FancyShower(Shower):
     def __post_init__(self):
         self.name = "FancyShower"
         self.wastewater_type = "greywater"
-    
+
 
 class WashingMachine(EndUse):
     #discharge_events: list = field(default_factory=list)
@@ -758,7 +753,7 @@ class WashingMachine(EndUse):
         pattern = self.statistics['enduse_pattern']
         # duration = pattern.index[-1] - pattern.index[0]
         return pattern
-    
+
     def calculate_discharge(self, discharge, start, j, ind_enduse, pattern_num, day_num, end_of_day, total_days, spillover=False):
         discharge_pattern = self.statistics['discharge_pattern']
 
@@ -789,7 +784,7 @@ class WashingMachine(EndUse):
             discharge_temperatures = dist(low=low, high=high, size=len(cycle_times)).tolist()
         else:
             raise ValueError("Discharge temperature type not implemented.")
-        
+
         self.discharge_events.append({
             'enduse': "WashingMachine",
             'usage': "WashingMachine", # no subtypes currently
@@ -825,7 +820,6 @@ class WashingMachine(EndUse):
 
         for i in range(freq):
             start, end = sample_start_time(prob_joint, day_num, duration, previous_events)
-            
             # add event times to list of previous events
             previous_events.append((start, end))
 
@@ -848,6 +842,7 @@ class WashingMachine(EndUse):
 
         return consumption, (discharge if simulate_discharge else None)
 
+
 @dataclass
 class Wc(EndUse):
     #discharge_events: list = field(default_factory=list)
@@ -856,7 +851,6 @@ class Wc(EndUse):
         self.name = "Wc"
         self.wastewater_type = "blackwater"
         self.discharge_events = []
-    
 
     def fct_frequency(self, age=None, gender=None):
         f_stats = self.statistics['frequency']
@@ -887,7 +881,6 @@ class Wc(EndUse):
 
         return duration, intensity, temperature
 
-
     def calculate_discharge(self, discharge, start, duration, intensity, temperature_fraction, j, ind_enduse, pattern_num, usage):
         incoming_water = intensity * duration
         end = int(start)
@@ -911,7 +904,6 @@ class Wc(EndUse):
             end = start
 
         return discharge
-
 
     def simulate(self, consumption, discharge=None, users=None, ind_enduse=None, pattern_num=1, day_num=0, total_days=1, simulate_discharge=False, spillover=False):
 
@@ -945,12 +937,14 @@ class Wc(EndUse):
 
         return consumption, (discharge if simulate_discharge else None)
 
+
 @dataclass
 class WcNormal(Wc):
 
     def __post_init__(self):
         self.name = 'WcNormal'
         self.wastewater_type = "blackwater"
+
 
 @dataclass
 class WcNormalSave(Wc):
@@ -959,12 +953,14 @@ class WcNormalSave(Wc):
         self.name = "WcNormalSave"
         self.wastewater_type = "blackwater"
 
+
 @dataclass
 class WcNew(Wc):
 
     def __post_init__(self):
         self.name = "WcNew"
         self.wastewater_type = "blackwater"
+
 
 @dataclass
 class WcNewSave(Wc):

--- a/pysimdeum/core/end_use.py
+++ b/pysimdeum/core/end_use.py
@@ -18,6 +18,10 @@ class EndUse:
     hot_water_temp = 60
     discharge_events = []
 
+    def __post_init__(self):
+        """Initialize field values that depend on other fields, among others."""
+        self.offset = int(pd.Timedelta(self.statistics['offset']).total_seconds())
+
     def init_consumption(self, users: list=None, time_resolution: str='1s') -> pd.DataFrame:
         """Initialization of a pandas dataframe to store the  consumptions.
 
@@ -104,6 +108,7 @@ class Bathtub(EndUse):
             name: End-use name as string.
             **kwargs: keyword arguments for super classes.
         """
+        super().__post_init__()
         self.name = "Bathtub"
         self.wastewater_type = "greywater"
         #self.discharge_events = []
@@ -205,7 +210,7 @@ class Bathtub(EndUse):
                 temperature = self.statistics['temperature']
                 prob_joint = normalize(prob_user * prob_usage)
 
-                start, end = sample_start_time(prob_joint, day_num, duration, previous_events)
+                start, end = sample_start_time(prob_joint, day_num, duration, previous_events, self.offset)
                 previous_events.append((start, end))
 
                 consumption[start:end, j, ind_enduse, pattern_num, 0] = intensity
@@ -224,6 +229,7 @@ class Bathtub(EndUse):
 class BathroomTap(EndUse):
     #discharge_events: list = field(default_factory=list)
     def __post_init__(self):
+        super().__post_init__()
         self.name = "BathroomTap"
         self.wastewater_type = "greywater"
         #self.discharge_events = []
@@ -301,7 +307,7 @@ class BathroomTap(EndUse):
 
                 prob_joint = normalize(prob_user * prob_usage)
 
-                start, end = sample_start_time(prob_joint, day_num, duration, previous_events)
+                start, end = sample_start_time(prob_joint, day_num, duration, previous_events, self.offset)
                 previous_events.append((start, end))
 
                 consumption[start:end, j, ind_enduse, pattern_num, 0] = intensity
@@ -321,6 +327,7 @@ class Dishwasher(EndUse):
     #discharge_events: list = field(default_factory=list)
 
     def __post_init__(self):
+        super().__post_init__()
         self.name = "Dishwasher"
         self.wastewater_type = "blackwater"
         #self.discharge_events = []
@@ -400,7 +407,7 @@ class Dishwasher(EndUse):
         previous_events = []
 
         for i in range(freq):
-            start, end = sample_start_time(prob_joint, day_num, duration, previous_events)
+            start, end = sample_start_time(prob_joint, day_num, duration, previous_events, self.offset)
 
             # add event times to list of previous events
             previous_events.append((start, end))
@@ -430,6 +437,7 @@ class KitchenTap(EndUse):
     #discharge_events: list = field(default_factory=list)
 
     def __post_init__(self):
+        super().__post_init__()
         self.name = "KitchenTap"
         self.wastewater_type = "blackwater"
         #self.discharge_events = []
@@ -544,7 +552,7 @@ class KitchenTap(EndUse):
             # assign usage type (based on subtype)
             usage = self.subtype
             prob_joint = normalize(prob_user * prob_usage)  # ToDo: Check if joint probability can be computed outside of for loop for all functions
-            start, end = sample_start_time(prob_joint, day_num, duration, previous_events)
+            start, end = sample_start_time(prob_joint, day_num, duration, previous_events, self.offset)
             previous_events.append((start, end))
 
             consumption[start:end, j, ind_enduse, pattern_num, 0] = intensity
@@ -563,6 +571,7 @@ class KitchenTap(EndUse):
 class OutsideTap(EndUse):
 
     def __post_init__(self):
+        super().__post_init__()
         self.name = "OutsideTap"
 
     def fct_frequency(self):
@@ -616,7 +625,7 @@ class OutsideTap(EndUse):
             duration, intensity, temperature = self.fct_duration_intensity_temperature()
 
             prob_joint = normalize(prob_user * prob_usage)
-            start, end = sample_start_time(prob_joint, day_num, duration, previous_events)
+            start, end = sample_start_time(prob_joint, day_num, duration, previous_events, self.offset)
             previous_events.append((start, end))
 
             consumption[start:end, j, ind_enduse, pattern_num, 0] = intensity
@@ -631,6 +640,7 @@ class Shower(EndUse):
     #discharge_events: list = field(default_factory=list)
 
     def __post_init__(self):
+        super().__post_init__()
         self.name = "Shower"
         self.wastewater_type = "greywater"
         #self.discharge_events = []
@@ -693,7 +703,6 @@ class Shower(EndUse):
     def simulate(self, consumption, discharge=None, users=None, ind_enduse=None, pattern_num=1, day_num=0, total_days=1, simulate_discharge=False, spillover=False):
 
         prob_usage = self.usage_probability().values
-
         previous_events = []
 
         for j, user in enumerate(users):
@@ -704,7 +713,7 @@ class Shower(EndUse):
                 duration, intensity, temperature = self.fct_duration_intensity_temperature(age=user.age)
 
                 prob_joint = normalize(prob_user * prob_usage)
-                start, end = sample_start_time(prob_joint, day_num, duration, previous_events)
+                start, end = sample_start_time(prob_joint, day_num, duration, previous_events, self.offset)
                 previous_events.append((start, end))
 
                 consumption[start:end, j, ind_enduse, pattern_num, 0] = intensity
@@ -722,12 +731,14 @@ class Shower(EndUse):
 class NormalShower(Shower):
 
     def __post_init__(self):
+        super().__post_init__()
         self.name = "NormalShower"
         self.wastewater_type = "greywater"
 
 class FancyShower(Shower):
 
     def __post_init__(self):
+        super().__post_init__()
         self.name = "FancyShower"
         self.wastewater_type = "greywater"
 
@@ -736,6 +747,7 @@ class WashingMachine(EndUse):
     #discharge_events: list = field(default_factory=list)
 
     def __post_init__(self):
+        super().__post_init__()
         self.name = "WashingMachine"
         self.wastewater_type = "blackwater"
         #self.discharge_events = []
@@ -819,7 +831,7 @@ class WashingMachine(EndUse):
         previous_events = []
 
         for i in range(freq):
-            start, end = sample_start_time(prob_joint, day_num, duration, previous_events)
+            start, end = sample_start_time(prob_joint, day_num, duration, previous_events, self.offset)
             # add event times to list of previous events
             previous_events.append((start, end))
 
@@ -848,6 +860,7 @@ class Wc(EndUse):
     #discharge_events: list = field(default_factory=list)
 
     def __post_init__(self):
+        super().__post_init__()
         self.name = "Wc"
         self.wastewater_type = "blackwater"
         self.discharge_events = []
@@ -923,7 +936,7 @@ class Wc(EndUse):
                 usage = "urine" if np.random.random() * 100 < self.statistics['prob_urine'] else "faeces"
                 #print(prob_user)
                 prob_joint = normalize(prob_user * prob_usage)
-                start, end = sample_start_time(prob_joint, day_num, duration, previous_events)
+                start, end = sample_start_time(prob_joint, day_num, duration, previous_events, self.offset)
                 previous_events.append((start, end))
 
                 consumption[start:end, j, ind_enduse, pattern_num, 0] = intensity
@@ -942,6 +955,7 @@ class Wc(EndUse):
 class WcNormal(Wc):
 
     def __post_init__(self):
+        super().__post_init__()
         self.name = 'WcNormal'
         self.wastewater_type = "blackwater"
 
@@ -950,6 +964,7 @@ class WcNormal(Wc):
 class WcNormalSave(Wc):
 
     def __post_init__(self):
+        super().__post_init__()
         self.name = "WcNormalSave"
         self.wastewater_type = "blackwater"
 
@@ -958,6 +973,7 @@ class WcNormalSave(Wc):
 class WcNew(Wc):
 
     def __post_init__(self):
+        super().__post_init__()
         self.name = "WcNew"
         self.wastewater_type = "blackwater"
 
@@ -966,5 +982,6 @@ class WcNew(Wc):
 class WcNewSave(Wc):
 
     def __post_init__(self):
+        super().__post_init__()
         self.name = "WcNewSave"
         self.wastewater_type = "blackwater"

--- a/pysimdeum/utils/patterns.py
+++ b/pysimdeum/utils/patterns.py
@@ -3,7 +3,7 @@ import pandas as pd
 from pysimdeum.utils.probability import normalize
 
 
-def sample_start_time(prob_joint, day_num, duration, previous_events):
+def sample_start_time(prob_joint, day_num, duration, previous_events, offset=0):
     """
     Samples a valid start time for an event, ensuring no overlap with previous events
     and no start within duration before the last sampled start time.
@@ -24,7 +24,7 @@ def sample_start_time(prob_joint, day_num, duration, previous_events):
         end = start + duration
 
         # Check for overlapping events or events within duration before the last sample start
-        if not any((start < event_end and start >= event_start) or (start < event_start and start >= event_start - int(duration)) for event_start, event_end in previous_events):
+        if not any((start < event_end + offset and start >= event_start) or (start < event_start and start >= event_start - int(duration) - offset) for event_start, event_end in previous_events):
             return int(start), int(end)
 
 

--- a/pysimdeum/utils/patterns.py
+++ b/pysimdeum/utils/patterns.py
@@ -2,20 +2,20 @@ import numpy as np
 import pandas as pd
 
 
-def sample_start_time(prob_joint, day_num, duration, previous_events, offset=0):
+def sample_start_time(prob_joint: np.ndarray, day_num: int, duration: int, previous_events: list, offset: int=0) -> (int, int):
     """
     Samples a valid start time for an event, ensuring no overlap with previous events
     and no start within duration before the last sampled start time.
 
     Args:
-        prob_joint (numpy.ndarray): The joint probability distribution.
-        day_num (int): The current day number in the simulation.
-        duration (int): The duration of the event.
-        previous_events (list): List of tuples containing start and end times of previous events.
+        prob_joint: The joint probability distribution with one point per second.
+        day_num: The current day number in the simulation.
+        duration: The duration of the event, in seconds.
+        previous_events: List of tuples containing the indices of the start and end of previous events.
+        offset: Time during which the event cannot happen again, in seconds.
 
     Returns:
-        int: The sampled start time.
-        int: The calculated end time.
+        The pair (tuple) of the sampled start time and calculated end time.
     """
     while True:
         start_index = np.random.choice(len(prob_joint), p=prob_joint)

--- a/pysimdeum/utils/patterns.py
+++ b/pysimdeum/utils/patterns.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pandas as pd
-from pysimdeum.utils.probability import normalize
 
 
 def sample_start_time(prob_joint, day_num, duration, previous_events, offset=0):

--- a/pysimdeum/utils/patterns.py
+++ b/pysimdeum/utils/patterns.py
@@ -24,7 +24,11 @@ def sample_start_time(prob_joint, day_num, duration, previous_events, offset=0):
         end = start + duration
 
         # Check for overlapping events or events within duration before the last sample start
-        if not any((start < event_end + offset and start >= event_start) or (start < event_start and start >= event_start - int(duration) - offset) for event_start, event_end in previous_events):
+        if not any(
+            (event_start <= start < event_end + offset)
+            or (start < event_start <= start + int(duration) + offset)
+            for event_start, event_end in previous_events
+        ):
             return int(start), int(end)
 
 

--- a/pysimdeum/utils/patterns.py
+++ b/pysimdeum/utils/patterns.py
@@ -17,7 +17,8 @@ def sample_start_time(prob_joint: np.ndarray, day_num: int, duration: int, previ
     Returns:
         The pair (tuple) of the sampled start time and calculated end time.
     """
-    while True:
+    max_attempts = 10000  # Define a maximum number of attempts to prevent infinite loops
+    for __ in range(max_attempts):
         start_index = np.random.choice(len(prob_joint), p=prob_joint)
         start = start_index + int(pd.to_timedelta('1 day').total_seconds()) * day_num
         end = start + duration
@@ -29,6 +30,8 @@ def sample_start_time(prob_joint: np.ndarray, day_num: int, duration: int, previ
             for event_start, event_end in previous_events
         ):
             return int(start), int(end)
+
+    raise RuntimeError(f"sample_start_time: Could not find a valid start time after {max_attempts} attempts.")
 
 
 def handle_spillover_consumption(consumption, pattern, start, end, j, ind_enduse, pattern_num, end_of_day, name, total_days):

--- a/testing/utils/test_patterns.py
+++ b/testing/utils/test_patterns.py
@@ -1,0 +1,69 @@
+import pytest
+import numpy as np
+
+from pysimdeum.utils.patterns import (
+    sample_start_time,
+)
+
+N_PTS = 24 * 60 * 60  # One point per second.
+
+
+@pytest.fixture
+def uniform_prob_joint():
+    """A uniform probability distribution for one day."""
+    return np.full(N_PTS, 1/N_PTS)
+
+
+@pytest.fixture
+def peak_prob_joint():
+    """A probability distribution with a single peak for one day."""
+    prob_joint = np.zeros(N_PTS)
+    peak_radius = 30
+    peak_start = N_PTS // 2 - peak_radius
+    peak_end = N_PTS // 2 + peak_radius
+    prob_joint[peak_start:peak_end] = 1.
+    return prob_joint / prob_joint.sum()
+
+
+@pytest.mark.parametrize("prob_joint_type", ["uniform", "peak"])
+@pytest.mark.parametrize("day_num", [0, 1])
+@pytest.mark.parametrize("duration", [60, 600])
+@pytest.mark.parametrize("previous_events", [
+    [],  # No previous events.
+    [(0, 10 * 60 * 60)],  # One previous event covering the first 10 hours of the first day.
+])
+@pytest.mark.parametrize("offset", [0, 7200])
+def test_sample_start_time(prob_joint_type, day_num, duration, previous_events, offset, uniform_prob_joint, peak_prob_joint):
+    """Tests the sample_start_time function under normal use."""
+    peak_radius = 30
+    if prob_joint_type == "uniform":
+        prob_joint = uniform_prob_joint
+    else:
+        prob_joint = peak_prob_joint
+
+    start, end = sample_start_time(prob_joint, day_num, duration, previous_events, offset)
+    assert isinstance(start, int)
+    assert isinstance(end, int)
+    assert (end - start) == duration
+    assert start >= day_num * N_PTS
+    # Test that the probability distribution is respected
+    if prob_joint_type == "peak":
+        assert day_num * N_PTS + N_PTS // 2 - peak_radius <= start <= day_num * N_PTS + N_PTS // 2 + peak_radius
+
+    # Test that the sampled time does not overlap with any previous events
+    for event_start, event_end in previous_events:
+        assert not (
+            (event_start <= start < event_end + offset)
+            or (start < event_start <= start + int(duration) + offset)
+        ), f"Sampled start {start}, end {end} overlaps with previous event ({event_start}, {event_end}) with offset {offset}"
+
+
+def test_sample_start_time_empty_prob_joint():
+    """Test with an empty prob_joint, expecting an error from np.random.choice."""
+    prob_joint = np.array([])
+    day_num = 0
+    duration = 60
+    previous_events = []
+
+    with pytest.raises(ValueError, match="a must be greater than 0"):
+        sample_start_time(prob_joint, day_num, duration, previous_events)

--- a/testing/utils/test_patterns.py
+++ b/testing/utils/test_patterns.py
@@ -64,6 +64,17 @@ def test_sample_start_time_empty_prob_joint():
     day_num = 0
     duration = 60
     previous_events = []
-
     with pytest.raises(ValueError, match="a must be greater than 0"):
         sample_start_time(prob_joint, day_num, duration, previous_events)
+
+
+def test_sample_start_time_inf_loop(peak_prob_joint):
+    """Test against infinite loops when all conditions are invalid."""
+    with pytest.raises(RuntimeError, match="Could not find a valid start time"):
+        previous_events = [(0, 24 * 60 * 60)]  # One previous event covering the full day.
+        sample_start_time(
+            prob_joint=peak_prob_joint,
+            day_num=0,
+            duration=60,
+            previous_events=previous_events
+        )


### PR DESCRIPTION
Fixes https://github.com/KWR-Water/pysimdeum/issues/99.

- Added support of the `offset` config parameter to all end uses.
- Added unit test for the `sample_start_time` function.
- Proposed refactoring of the end uses to simplify the code and improve long-term legibility and maintenance.