### PR TITLE
feat: support any type of statistical distribution in the configuration.

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -15,11 +15,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v2
+    - uses: actions/checkout@v6
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v6
       with:
-        python-version: 3.8
+        python-version: '3.10'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -206,7 +206,7 @@ The following changes won't work:
 - Changing a constant to be a statistical variable and vice-versa.
 - Changing the variable upon which distribution parameters depend.
   For instance, if a distribution depends on the age of the householder, you cannot change it to depend on their gender.
-- Making distribution parameters more complex, like making them dependant on the age if it is not already the case.
+- Making distribution parameters more complex, like making them dependent on the age if it is not already the case.
 
 ## Bathroom Tap
 
@@ -218,7 +218,7 @@ This file defines the statistics and parameters for the `BathroomTap` end-use in
 - `offset` (integer): Defines the time where a second use of the end-use is blocked.
 - `frequency`: the frequency distribution of the end-use
     - `distribution` (string): Type of distribution from where the frequency of the end-use will be drawn. Example: `'Poisson'`.
-    - `average` (float): Average frequency of end-use.
+    - `average` (float): Average number of events per person per day.
 - `subtype`: types of bathroom tap end-use. Each subtype has its own parameters
     - `subtype.appliance_use`
         - `penetration` (float): Probability of subtype use [%].
@@ -283,7 +283,7 @@ This file defines the statistics and parameters for the `Bathtub` end-use in the
     - `5` (integer): Penetration rate for houses with 5 people.
 - `frequency`: distribution of the end-use. Bathtub use is age-dependent, therefore the input parameter of the Poisson distribution changes with age.
     - `distribution` (string): Type of distribution from where the frequency of the end-use will be drawn. Example: `'Poisson'`.
-    - `frequency.average`
+    - `frequency.average`: Average number of baths per person per day.
         - `child` (float): Average frequency for children.
         - `teen` (float): Average frequency for teenagers.
         - `work_ad` (float): Average frequency for working adults
@@ -323,7 +323,7 @@ This file defines the statistics and parameters for the `Dishwasher` end-use in 
     - `5` (integer): Penetration rate for houses with 5 people.
 - `frequency`: frequency distribution of the end-use.
     - `distribution` (string): Type of distribution from where the frequency of the end-use will be drawn. Example: `'Poisson'`.
-    - `frequency.average`
+    - `frequency.average`: Average number of dishwasher cycles per day per household.
         - `1` (float): Average frequency for houses with 1 person.
         - `2` (float): Average frequency for houses with 2 people.
         - `3` (float): Average frequency for houses with 3 people.
@@ -339,7 +339,7 @@ This file defines the statistics and parameters for the `KitchenTap` end-use in 
 - `offset` (integer): Defines the time where a second use of the end-use is blocked.
 - `frequency`: frequency distribution of the end-use.
     - `distribution` (string): Type of distribution from where the frequency of the end-use will be drawn. Example: `'Negative_binomial'`.
-    - `frequency.average`:
+    - `frequency.average`: Average number of events per day per household.
         - `1` (float): Average frequency for houses with 1 person.
         - `2` (float): Average frequency for houses with 2 people.
         - `3` (float): Average frequency for houses with 3 people.
@@ -406,7 +406,7 @@ This file defines the statistics and parameters for the `OutsideTap` end-use in 
 - `offset` (integer): Defines the time where a second use of the end-use is blocked.
 - `frequency`: frequency distribution of the end-use.
     - `distribution` (string): Type of distribution from where the frequency of the end-use will be drawn. Example: `'Negative_binomial'`.
-    - `average` (float): Average frequency of end-use.
+    - `average` (float): Average frequency of end-use, i.e. average number of outdoor events per day per household.
 - `subtype`: types of kitchen tap end-use. Each subtype has its own parameters
     - `subtype.appliance_use`
         - `penetration` (float): Probability of subtype use [%].
@@ -459,8 +459,8 @@ This file defines the statistics and parameters for the `Shower ` end-use in the
 - `offset` (integer): Defines the time where a second use of the end-use is blocked.
 - `temperature` (integer): Temperature of used water [°C].
 - `frequency`: frequency distribution of the end-use. Age dependent.
-    - `distribution` (string): Type of distribution from where the frequency of the end-use will be drawn. Example: `'binomial'`.
-    - `n` (float): number of showers per day
+    - `distribution` (string): Type of distribution from where the frequency of the end-use will be drawn. Example: `'Binomial'`.
+    - `n` (float): Number of showers per day per person.
     - `frequency.p`
         - `age_group` (float): There should be a different entry for each age grouping. Value is the probability of the age taking a shower on a given day.
 - `duration`: Age dependent. Duration of a shower for each of the age groups.
@@ -517,7 +517,7 @@ This file defines the statistics and parameters for the `WashingMachine` end-use
     - `5` (integer): Penetration rate for houses with 5 people.
 - `frequency`: Frequency distribution of the end-use.
     - `distribution` (string): Type of distribution from where the frequency of the end-use will be drawn. Example: `'Poisson'`.
-    - `frequency.average`: Average frequency of end-use.
+    - `frequency.average`: Average number of laundry cycles per day per household.
         - `1` (float): Average frequency for houses with 1 person.
         - `2` (float): Average frequency for houses with 2 people.
         - `3` (float): Average frequency for houses with 3 people.
@@ -540,7 +540,7 @@ This file defines the statistics and parameters for the `Wc` (toilet) end-use in
 - `discharge_intensity` (float): Discharge intensity [L/s].
 - `frequency`: Contains the frequency distribution data.
     - `distribution` (string): Type of distribution from where the frequency of the end-use will be drawn. Example: `'Poisson'`.
-    - `frequency.average`: Average frequency of use, dependent on age and gender.
+    - `frequency.average`: Average number of flushes per person per day, dependent on age and gender.
         - `child`: Average frequency for children.
             - `male` (float): Average frequency for male children [day^(-1)].
             - `female` (float): Average frequency for female children [day^(-1)].

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -145,6 +145,69 @@ subcatchment_id = "subcatchme"
 ...
 ```
 
+## End uses
+
+End uses of water correspond to the fixture or appliance withdrawing and discharging the water.
+Each end use is linked to a `class` in the simulator and a TOML file configuring its statistics.
+End uses may have subtypes describing particular water jobs.
+For instance, washing the dishes at the kitchen sink uses water at a different temperature and for a different duration than other kitchen sink jobs.
+
+The configuration of an end use includes both constants and statistical variables.
+Sub-bullets including the `distribution` keyword declare the latter.
+You can change the distribution as long as you provide the right parameters.
+pySimdeum uses `numpy` under the hood and supports all distributions listed [here](https://numpy.org/doc/stable/reference/random/generator.html#distributions).
+If you change the distribution name, you **must** change the parameter name(s) to match `numpy`'s keyword arguments (see example below).
+Additionally, pySimdeum currently supports the following configurations (see table).
+
+Distribution        | Accepted parameter    | Comment
+--------------------|-----------------------|------------------
+Poisson             | `average`             | Used as lambda.
+Negative Binomial   | `average`, `sigma`    | Converted to r and p.
+Lognormal           | `average`             | Converted to `mean = log(average) - 0.5` and `sigma = 1.`
+
+### Example
+
+For instance, changing the distribution of the shower frequency from binomial to uniform is possible.
+
+#### Old configuration
+
+```toml
+[frequency]
+    distribution = 'Binomial'
+    n = 1
+    [frequency.p]
+        child = 0.48
+        teen = 0.67
+        work_ad = 0.79
+        ...
+```
+
+#### New configuration
+
+The binomial distribution requires the parameters `n` (number of trials) and `p` (probability of success).
+However, the uniform distribution requires the lower and upper bounds of the range.
+Therefore, the configuration below changes the `distribution` parameter and the parameter names.
+
+```toml
+[frequency]
+    distribution = 'Uniform'
+    high = 2  # Use the same syntax as low to make it age-dependent, too.
+    [frequency.low]
+        child = 0
+        teen = 1
+        work_ad = 1
+        ...
+```
+
+### ⚠️ Limitations
+
+While pySimdeum supports different distributions, it does currently not support changes to the structure of the configuration.
+The following changes won't work:
+- Changing a constant to be a statistical variable and vice-versa.
+- Changing the variable upon which distribution parameters depend.
+  For instance, if a distribution depends on the age of the householder, you cannot change it to depend on their gender.
+- Making distribution parameters more complex, like making them dependant on the age if it is not already the case.
+
 ## Bathroom Tap
 
 This file defines the statistics and parameters for the `BathroomTap` end-use in the simulation. The structure of the file is as follows:
@@ -165,7 +228,7 @@ This file defines the statistics and parameters for the `BathroomTap` end-use in
             - `average` (string): Average duration of use. Example: `'40 Seconds'`.
         - `subtype.appliance_use.intensity`: Water usage intensity patterns.
             - `distribution` (string): Distribution type. Example: `'Uniform'`.
-            - `low` (float): Lower bound of intensity.
+            - `low` (float): Lower bound of intensity [L/s].
             - `high` (float): Upper bound of intensity.
         - `subtype.appliance_use.discharge_intensity`: Discharging water intensity patterns.
             - `distribution` (string): Distribution type. Example: `'Uniform'`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,8 @@
 [build-system]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+pythonpath = [
+  "."
+]

--- a/pysimdeum/core/end_use.py
+++ b/pysimdeum/core/end_use.py
@@ -118,10 +118,16 @@ class EndUse:
 
         return dist_name, dist_params
 
-    def fct_frequency(self):
-        """Placeholder for specific frequency probability function defined in specific EndUse"""
+    def fct_frequency(self) -> int:
+        """Samples a number of events from the frequency probability function defined in the EndUse configuration.
 
-        raise NotImplementedError('Frequency function is not implemented yet!')
+        Simple case where the distribution parameters are constant.
+
+        Returns:
+            An integer value representing the number of events for the given day.
+        """
+        dist_name, dist_params = self.get_statistical_params(self.statistics['frequency'])
+        return round(sample_value(dist_name, **dist_params))
 
     def fct_duration(self):
         """Placeholder for specific duration probability function defined in specific EndUse"""
@@ -262,10 +268,6 @@ class BathroomTap(EndUse):
     """Base class for bathroom taps."""
     name: str = "BathroomTap"
     wastewater_type: str = "greywater"
-
-    def fct_frequency(self) -> int:
-        dist_name, dist_params = self.get_statistical_params(self.statistics['frequency'])
-        return round(sample_value(dist_name, **dist_params))
 
     def fct_duration_intensity_temperature(self):
         self.subtype = chooser(self.statistics['subtype'], 'penetration')
@@ -533,10 +535,6 @@ class KitchenTap(EndUse):
 class OutsideTap(EndUse):
     """Base class for outdoor water use."""
     name: str = "OutsideTap"
-
-    def fct_frequency(self):
-        dist_name, dist_params = self.get_statistical_params(self.statistics['frequency'])
-        return round(sample_value(dist_name, **dist_params))
 
     def fct_duration_intensity_temperature(self):
         self.subtype = chooser(self.statistics['subtype'], 'penetration')

--- a/pysimdeum/core/end_use.py
+++ b/pysimdeum/core/end_use.py
@@ -21,7 +21,7 @@ class EndUse:
         """Initialize field values that depend on other fields, among others."""
         self.offset = int(pd.Timedelta(self.statistics['offset']).total_seconds())
 
-    def init_consumption(self, users: list=None, time_resolution: str='1s') -> pd.DataFrame:
+    def init_consumption(self, users: list, time_resolution: str='1s') -> pd.DataFrame:
         """Initialization of a pandas dataframe to store the  consumptions.
 
         Args:
@@ -31,11 +31,14 @@ class EndUse:
 
         Returns:
             consumption as pandas `DataFrame` filled with zeros
+
+        Raise:
+            KeyError:   If no users are provided.
         """
 
         if users:
             # produce datetime index
-            index = pd.TimedeltaIndex(start='00:00:00', end='24:00:00', freq=time_resolution, closed='left')
+            index = pd.timedelta_range(start='00:00:00', end='24:00:00', freq=time_resolution, closed='left')
 
             # name columns by users
             columns = ['user_' + str(x+1) for x, user in enumerate(users)]
@@ -43,10 +46,9 @@ class EndUse:
             # initialise consumption dataframe with timedelta index and user columnnames, name it according to end-use
             # device and fill it with zeros.
             consumption = pd.DataFrame(data=0, index=index, columns=columns)
-            consumption.name = self.name
         else:
             # raise an error if no users are defined.
-            raise Exception('No Users are defined!')
+            raise KeyError('No Users are defined!')
 
         return consumption
 

--- a/pysimdeum/core/end_use.py
+++ b/pysimdeum/core/end_use.py
@@ -4,7 +4,6 @@ import numpy as np
 from dataclasses import dataclass, field
 from pysimdeum.utils.probability import chooser, duration_decorator, normalize, to_timedelta
 from pysimdeum.utils.patterns import handle_spillover_consumption, handle_discharge_spillover, sample_start_time, offset_simultaneous_discharge
-from pysimdeum.core.statistics import Statistics
 
 
 #TODO: Specific EndUse __post_init__ calls can be replaced by directly using the class name instead of setting the name attributes
@@ -12,7 +11,7 @@ from pysimdeum.core.statistics import Statistics
 @dataclass
 class EndUse:
     """Base class for end-uses."""
-    statistics: Statistics = field(repr=False)  # ... statistic object associated with end-use
+    statistics: dict = field(repr=False)  # dict object from core.Statistics.end_uses associated with the end-use
     name: str = "EndUse"  # ... name of the end-use
     cold_water_temp = 10
     hot_water_temp = 60

--- a/pysimdeum/core/end_use.py
+++ b/pysimdeum/core/end_use.py
@@ -346,7 +346,7 @@ class Dishwasher(EndUse):
     wastewater_type: str = "blackwater"
 
     def fct_frequency(self, numusers=None):
-        dist_name, dist_params = self.get_statistical_params(self.statistics['frequency'], numusers=numusers)  # TODO: change the frequency config because it no longer multiplies by numusers.
+        dist_name, dist_params = self.get_statistical_params(self.statistics['frequency'], numusers=numusers)
         return round(sample_value(dist_name, **dist_params))
 
     def fct_duration_pattern(self, start=None):
@@ -657,7 +657,7 @@ class WashingMachine(EndUse):
     wastewater_type: str = "blackwater"
 
     def fct_frequency(self, numusers=None):
-        dist_name, dist_params = self.get_statistical_params(self.statistics['frequency'], numusers=numusers)  # TODO: change the frequency config because it no longer multiplies by numusers.
+        dist_name, dist_params = self.get_statistical_params(self.statistics['frequency'], numusers=numusers)
         return round(sample_value(dist_name, **dist_params))
 
     def fct_duration_pattern(self, start=None):

--- a/pysimdeum/core/end_use.py
+++ b/pysimdeum/core/end_use.py
@@ -67,6 +67,52 @@ class EndUse:
 
         return prob
 
+    def get_statistical_params(self, dist_config: dict, age: str|None=None, gender: str|None=None, numusers: int|None=None) -> tuple[str, dict]:
+        """Split the statistical configuration into a distribution name and distribution parameters.
+
+        Use before calling `utils.probability.sample_value`.
+        This function supports the following use cases:
+            - The parameters of the statistical distribution are constant.
+            - The parameters of the statistical distribution depend on the size of the household.
+            - The parameters of the statistical distribution depend on the age category of the user.
+            - The parameters of the statistical distribution depend on the age category of the user and their gender.
+
+        Args:
+            dist_config:    The configuration of the statistical distribution, as found in `Statistics.end_uses`.
+                            It **must** have a key called `'distribution'`.
+            age:            The age category of the user (child, teen, work_ad, home_ad, senior, total).
+                            Use if the distribution parameters depend on it.
+            gender:         The gender of the user (female, male).
+                            Use if the distribution parameters depend on it.
+            numusers:       The number of users, i.e. the household size.
+                            Use if the distribution parameters depend on it.
+
+        Returns:
+            dist_name:      The name of the distribution.
+            dist_params:    The parameters of the distribution, as a single-level map.
+
+        Raise:
+            KeyError:       If `dist_config` has no `'distribution'` key, or if the given `age`, `gender`, or `numusers` is not found in the nested parameter dict.
+        """
+        dist_config_copy = copy.deepcopy(dist_config)  # Avoid any side-effects of the function.
+        dist_name = dist_config_copy.pop('distribution')
+        if any([age, gender, numusers]):
+            dist_params = {}
+            for param_name, param_value in dist_config_copy.items():
+                if isinstance(param_value, dict):
+                    if age is not None and gender is not None:
+                        dist_params[param_name] = param_value[age][gender]
+                    elif age is not None:
+                        dist_params[param_name] = param_value[age]
+                    elif numusers is not None:
+                        dist_params[param_name] = param_value[str(numusers)]
+                else:
+                    dist_params[param_name] = param_value
+        else:
+            dist_params = dist_config_copy
+
+        return dist_name, dist_params
+
     def fct_frequency(self):
         """Placeholder for specific frequency probability function defined in specific EndUse"""
 

--- a/pysimdeum/core/end_use.py
+++ b/pysimdeum/core/end_use.py
@@ -454,7 +454,7 @@ class KitchenTap(EndUse):
 
         # Sample a value from the discharge_intensity distribution
         dist_name, dist_params = self.get_statistical_params(self.statistics['subtype'][self.subtype]['discharge_intensity'])
-        discharge_flow_rate = sample_value(dist_name, **dist_params)  # TODO: change the lower bound to ensure flow rate > 0 instead of the while-loop.
+        discharge_flow_rate = sample_value(dist_name, **dist_params)
 
         # limit discharge_flow_rate to the intensity of the tap if there is not enough water to discharge
         if discharge_flow_rate > intensity:
@@ -463,24 +463,27 @@ class KitchenTap(EndUse):
         # Check if the tap is turned off before the end of the duration, if so, update the start time
         start = offset_simultaneous_discharge(discharge, start, j, ind_enduse, pattern_num, spillover=spillover)
 
-        self.discharge_events.append({
-            'enduse': self.name,
-            'usage': usage, # subtypes are from chooser(toml)
-            'start': start,
-            'end': int(start + (remaining_water / discharge_flow_rate)),
-            'discharge_temperature': self.statistics['subtype'][self.subtype]['discharge_temperature'],
-        })
+        if discharge_flow_rate > 0.:
+            self.discharge_events.append({
+                'enduse': self.name,
+                'usage': usage, # subtypes are from chooser(toml)
+                'start': start,
+                'end': int(start + (remaining_water / discharge_flow_rate)),
+                'discharge_temperature': self.statistics['subtype'][self.subtype]['discharge_temperature'],
+            })
 
-        while remaining_water > 0:
-            discharge_duration = remaining_water / discharge_flow_rate
-            end = int(start + discharge_duration)
-            # check if subtype = consumption (drinking), if so the discharge flow rate is set to 0
-            if self.subtype == 'consumption':
-                discharge[start:end, j, ind_enduse, pattern_num, 1] = 0
-            else:
-                discharge[start:end, j, ind_enduse, pattern_num, 1] = discharge_flow_rate         
-            remaining_water -= discharge_flow_rate * discharge_duration
-            start = end
+            while remaining_water > 0:
+                discharge_duration = remaining_water / discharge_flow_rate
+                end = int(start + discharge_duration)
+                # check if subtype = consumption (drinking), if so the discharge flow rate is set to 0
+                if self.subtype == 'consumption':
+                    discharge[start:end, j, ind_enduse, pattern_num, 1] = 0
+                else:
+                    discharge[start:end, j, ind_enduse, pattern_num, 1] = discharge_flow_rate
+                remaining_water -= discharge_flow_rate * discharge_duration
+                start = end
+
+        # else: the event is consumption and there is no discharge.
 
         return discharge
 

--- a/pysimdeum/core/end_use.py
+++ b/pysimdeum/core/end_use.py
@@ -433,8 +433,8 @@ class KitchenTap(EndUse):
         # Todo: find out which implementation is right? Mirjam (implemented here) or Wikipedia
 
         # Implementation according to Wikipedia
-        # p = (sigma ** 2 - average) / (sigma ** 2)
-        # r = (average ** 2) / (sigma ** 2 - average)
+        # p = (sigma ** 2 - average) / (sigma ** 2)  Wrong! Wikipedia states: p = average / sigma**2
+        # r = (average ** 2) / (sigma ** 2 - average)  Correct! Equivalent to Mirjam's formula.
 
         # implementation according to Mirjam
         p = average / sigma ** 2

--- a/pysimdeum/core/end_use.py
+++ b/pysimdeum/core/end_use.py
@@ -144,13 +144,24 @@ class EndUse:
 
         raise NotImplementedError('temperature function is not implemented yet!')
 
-    def fct_duration_intensity_temperature(self):
-        """Computing duration and intensity for enduse and retrieve temperature for enduse"""
+    def fct_duration_intensity_temperature(self) -> tuple[int, float, float]:
+        """Computes event duration and flow rate intensity and temperature for the end use.
 
-        duration = self.fct_duration()
-        intensity = self.fct_intensity()
-        temperature = self.temperature()
+        Use this function if the duration, intensity, and temperature depend on each other.
+        For instance, they all depend on the subtype (washing hands, etc.).
+        Side effect: add the `subtype` attribute to the end use object.
 
+        Returns:
+            duration:       The total time of the water use, in seconds.
+            intensity:      The flow rate of the water use, in liters per second.
+            temperature:    The water temperature, in degrees Celsius.
+        """
+        self.subtype = chooser(self.statistics['subtype'], 'penetration')
+        d_dist, d_stats = self.get_statistical_params(self.statistics['subtype'][self.subtype]['duration'])
+        duration = round(sample_value(d_dist, **d_stats))
+        i_dist, i_stats = self.get_statistical_params(self.statistics['subtype'][self.subtype]['intensity'])
+        intensity = sample_value(i_dist, **i_stats)
+        temperature = self.statistics['subtype'][self.subtype]['temperature']
         return duration, intensity, temperature
 
 
@@ -268,15 +279,6 @@ class BathroomTap(EndUse):
     """Base class for bathroom taps."""
     name: str = "BathroomTap"
     wastewater_type: str = "greywater"
-
-    def fct_duration_intensity_temperature(self):
-        self.subtype = chooser(self.statistics['subtype'], 'penetration')
-        d_dist, d_stats = self.get_statistical_params(self.statistics['subtype'][self.subtype]['duration'])
-        duration = round(sample_value(d_dist, **d_stats))
-        i_dist, i_stats = self.get_statistical_params(self.statistics['subtype'][self.subtype]['intensity'])
-        intensity = sample_value(i_dist, **i_stats)
-        temperature = self.statistics['subtype'][self.subtype]['temperature']
-        return duration, intensity, temperature
 
     def calculate_discharge(self, discharge, start, duration, intensity, temperature_fraction, j, ind_enduse, pattern_num, spillover=False):
         remaining_water = intensity * duration
@@ -446,15 +448,6 @@ class KitchenTap(EndUse):
         dist_name, dist_params = self.get_statistical_params(self.statistics['frequency'], numusers=numusers)
         return round(sample_value(dist_name, **dist_params))
 
-    def fct_duration_intensity_temperature(self):
-        self.subtype = chooser(self.statistics['subtype'], 'penetration')
-        d_dist, d_stats = self.get_statistical_params(self.statistics['subtype'][self.subtype]['duration'])
-        duration = round(sample_value(d_dist, **d_stats))
-        i_dist, i_stats = self.get_statistical_params(self.statistics['subtype'][self.subtype]['intensity'])
-        intensity = sample_value(i_dist, **i_stats)
-        temperature = self.statistics['subtype'][self.subtype]['temperature']
-        return duration, intensity, temperature
-
     def calculate_discharge(self, discharge, start, duration, intensity, temperature_fraction, j, ind_enduse, pattern_num, usage, spillover=False):
         remaining_water = intensity * duration
         start = int(start)
@@ -535,15 +528,6 @@ class KitchenTap(EndUse):
 class OutsideTap(EndUse):
     """Base class for outdoor water use."""
     name: str = "OutsideTap"
-
-    def fct_duration_intensity_temperature(self):
-        self.subtype = chooser(self.statistics['subtype'], 'penetration')
-        d_dist, d_stats = self.get_statistical_params(self.statistics['subtype'][self.subtype]['duration'])
-        duration = round(sample_value(d_dist, **d_stats))
-        i_dist, i_stats = self.get_statistical_params(self.statistics['subtype'][self.subtype]['intensity'])
-        intensity = sample_value(i_dist, **i_stats)
-        temperature = self.statistics['subtype'][self.subtype]['temperature']
-        return duration, intensity, temperature
 
     def simulate(self, consumption, discharge=None, users=None, ind_enduse=None, pattern_num=1, day_num=0, total_days=1, simulate_discharge=False, spillover=False):
 

--- a/pysimdeum/core/end_use.py
+++ b/pysimdeum/core/end_use.py
@@ -2,7 +2,12 @@ import copy
 import pandas as pd
 import numpy as np
 from dataclasses import dataclass, field
-from pysimdeum.utils.probability import chooser, duration_decorator, normalize, to_timedelta
+from pysimdeum.utils.probability import (
+    chooser,
+    normalize,
+    to_timedelta,
+    sample_value,
+)
 from pysimdeum.utils.patterns import handle_spillover_consumption, handle_discharge_spillover, sample_start_time, offset_simultaneous_discharge
 
 
@@ -149,21 +154,17 @@ class Bathtub(EndUse):
     name: str = "Bathtub"
     wastewater_type: str = "greywater"
 
-    def fct_frequency(self, age=None):
+    def fct_frequency(self, age:str|None=None):
         """Random function computing the frequency of use for the Bathtub end-use class.
 
         Args:
-            age: age of the user in years.
+            age: age category of the user of the user (child, teen, etc.).
 
         Returns:
-            distribution function from `numpy.random` to compute frequency of use.
-
+            A sampled value of the frequency of use from the distribution.
         """
-        f_stats = self.statistics['frequency']
-        distribution = getattr(np.random, f_stats['distribution'].lower())
-        average = f_stats['average'][age]
-
-        return distribution(average)
+        dist_name, dist_params = self.get_statistical_params(self.statistics['frequency'], age=age)
+        return round(sample_value(dist_name, **dist_params))
 
     def fct_duration(self):
         """Function to compute the duration of Bathtub end-use.
@@ -199,19 +200,14 @@ class Bathtub(EndUse):
 
     def calculate_discharge(self, discharge, end, duration, intensity, temperature_fraction, j, ind_enduse, pattern_num):
         remaining_water = intensity * duration
-
-        # Sample a usage_delay from a uniform distribution
-        usage_delay_stats = self.statistics['usage_delay']
-        usage_delay = np.random.uniform(usage_delay_stats['low'], usage_delay_stats['high']) * 60
-
+        # Sample a usage_delay from the distribution
+        dist_name, dist_params = self.get_statistical_params(self.statistics['usage_delay'])
+        usage_delay = sample_value(dist_name, **dist_params) * 60.
         start = int(end + usage_delay)
 
         # Sample a value from the discharge_intensity distribution
-        discharge_intensity_stats = self.statistics['discharge_intensity']
-        dist = getattr(np.random, discharge_intensity_stats['distribution'].lower())
-        low = discharge_intensity_stats['low']
-        high = discharge_intensity_stats['high']
-        discharge_flow_rate = dist(low=low, high=high)
+        dist_name, dist_params = self.get_statistical_params(self.statistics['discharge_intensity'])
+        discharge_flow_rate = sample_value(dist_name, **dist_params)
 
         self.discharge_events.append({
             'enduse': self.name,
@@ -267,29 +263,16 @@ class BathroomTap(EndUse):
     name: str = "BathroomTap"
     wastewater_type: str = "greywater"
 
-    def fct_frequency(self):
-
-        f_stats = self.statistics['frequency']
-        distribution = getattr(np.random, f_stats['distribution'].lower())
-        average = f_stats['average']
-        return distribution(average)
+    def fct_frequency(self) -> int:
+        dist_name, dist_params = self.get_statistical_params(self.statistics['frequency'])
+        return round(sample_value(dist_name, **dist_params))
 
     def fct_duration_intensity_temperature(self):
-
         self.subtype = chooser(self.statistics['subtype'], 'penetration')
-
-        d_stats = self.statistics['subtype'][self.subtype]['duration']
-        i_stats = self.statistics['subtype'][self.subtype]['intensity']
-
-        dist = duration_decorator(getattr(np.random, d_stats['distribution'].lower()))
-        mean = to_timedelta(np.log(to_timedelta(d_stats['average']).total_seconds()) - 0.5)
-        duration = dist(mean=mean).total_seconds()
-
-        dist = getattr(np.random, i_stats['distribution'].lower())
-        low = i_stats['low']
-        high = i_stats['high']
-
-        intensity = dist(low=low, high=high)
+        d_dist, d_stats = self.get_statistical_params(self.statistics['subtype'][self.subtype]['duration'])
+        duration = round(sample_value(d_dist, **d_stats))
+        i_dist, i_stats = self.get_statistical_params(self.statistics['subtype'][self.subtype]['intensity'])
+        intensity = sample_value(i_dist, **i_stats)
         temperature = self.statistics['subtype'][self.subtype]['temperature']
         return duration, intensity, temperature
 
@@ -298,11 +281,8 @@ class BathroomTap(EndUse):
         start = int(start)
 
         # Sample a value from the discharge_intensity distribution
-        discharge_intensity_stats = self.statistics['subtype'][self.subtype]['discharge_intensity']
-        dist = getattr(np.random, discharge_intensity_stats['distribution'].lower())
-        low = discharge_intensity_stats['low']
-        high = discharge_intensity_stats['high']
-        discharge_flow_rate = dist(low=low, high=high)
+        dist_name, dist_params = self.get_statistical_params(self.statistics['subtype'][self.subtype]['discharge_intensity'])
+        discharge_flow_rate = sample_value(dist_name, **dist_params)
 
         # limit discharge_flow_rate to the intensity of the tap if there is not enough water to discharge
         if discharge_flow_rate > intensity:
@@ -362,13 +342,8 @@ class Dishwasher(EndUse):
     wastewater_type: str = "blackwater"
 
     def fct_frequency(self, numusers=None):
-
-        f_stats = self.statistics['frequency']
-        distribution = getattr(np.random, f_stats['distribution'].lower())
-
-        df = pd.Series(f_stats['average'])
-        average = df[str(numusers)]  * numusers
-        return distribution(average)
+        dist_name, dist_params = self.get_statistical_params(self.statistics['frequency'], numusers=numusers)  # TODO: change the frequency config because it no longer multiplies by numusers.
+        return round(sample_value(dist_name, **dist_params))
 
     def fct_duration_pattern(self, start=None):
         pattern = self.statistics['enduse_pattern']
@@ -397,10 +372,8 @@ class Dishwasher(EndUse):
         if isinstance(discharge_temperature, (int, float)):
             discharge_temperatures = [discharge_temperature] * len(cycle_times)
         elif isinstance(discharge_temperature, dict):
-            dist = getattr(np.random, discharge_temperature['distribution'].lower())
-            low = discharge_temperature['low']
-            high = discharge_temperature['high']
-            discharge_temperatures = dist(low=low, high=high, size=len(cycle_times)).tolist()
+            dist_name, dist_params = self.get_statistical_params(discharge_temperature)
+            discharge_temperatures = [sample_value(dist_name, **dist_params) for __ in cycle_times]
         else:
             raise ValueError("Discharge temperature type not implemented.")
 
@@ -468,47 +441,16 @@ class KitchenTap(EndUse):
     wastewater_type: str = "blackwater"
 
     def fct_frequency(self, numusers=None):
-
-        f_stats = self.statistics['frequency']
-        distribution = getattr(np.random, f_stats['distribution'].lower())
-
-        df = pd.Series(f_stats['average'])
-        average = df[str(numusers)]
-
-        df = pd.Series(f_stats['sigma'])
-        sigma = df[str(numusers)]
-
-        # Todo: find out which implementation is right? Mirjam (implemented here) or Wikipedia
-
-        # Implementation according to Wikipedia
-        # p = (sigma ** 2 - average) / (sigma ** 2)  Wrong! Wikipedia states: p = average / sigma**2
-        # r = (average ** 2) / (sigma ** 2 - average)  Correct! Equivalent to Mirjam's formula.
-
-        # implementation according to Mirjam
-        p = average / sigma ** 2
-        r = p * average / (1 - p)
-
-        return distribution(r, p)
+        dist_name, dist_params = self.get_statistical_params(self.statistics['frequency'], numusers=numusers)
+        return round(sample_value(dist_name, **dist_params))
 
     def fct_duration_intensity_temperature(self):
-
         self.subtype = chooser(self.statistics['subtype'], 'penetration')
-
-        d_stats = self.statistics['subtype'][self.subtype]['duration']
-        i_stats = self.statistics['subtype'][self.subtype]['intensity']
-
-        dist = getattr(np.random, d_stats['distribution'].lower())
-        mean = np.log(pd.Timedelta(d_stats['average']).total_seconds()) - 0.5
-
-        duration = int(pd.Timedelta(seconds=dist(mean=mean)).total_seconds())
-
-        dist = getattr(np.random, i_stats['distribution'].lower())
-        low = i_stats['low']
-        high = i_stats['high']
-
-        intensity = dist(low=low, high=high)
+        d_dist, d_stats = self.get_statistical_params(self.statistics['subtype'][self.subtype]['duration'])
+        duration = round(sample_value(d_dist, **d_stats))
+        i_dist, i_stats = self.get_statistical_params(self.statistics['subtype'][self.subtype]['intensity'])
+        intensity = sample_value(i_dist, **i_stats)
         temperature = self.statistics['subtype'][self.subtype]['temperature']
-
         return duration, intensity, temperature
 
     def calculate_discharge(self, discharge, start, duration, intensity, temperature_fraction, j, ind_enduse, pattern_num, usage, spillover=False):
@@ -516,13 +458,8 @@ class KitchenTap(EndUse):
         start = int(start)
 
         # Sample a value from the discharge_intensity distribution
-        discharge_intensity_stats = self.statistics['subtype'][self.subtype]['discharge_intensity']
-        dist = getattr(np.random, discharge_intensity_stats['distribution'].lower())
-        low = discharge_intensity_stats['low']
-        high = discharge_intensity_stats['high']
-        discharge_flow_rate = 0
-        while discharge_flow_rate == 0: #ensure the discharge is not zero
-            discharge_flow_rate = dist(low=low, high=high)
+        dist_name, dist_params = self.get_statistical_params(self.statistics['subtype'][self.subtype]['discharge_intensity'])
+        discharge_flow_rate = sample_value(dist_name, **dist_params)  # TODO: change the lower bound to ensure flow rate > 0 instead of the while-loop.
 
         # limit discharge_flow_rate to the intensity of the tap if there is not enough water to discharge
         if discharge_flow_rate > intensity:
@@ -598,31 +535,16 @@ class OutsideTap(EndUse):
     name: str = "OutsideTap"
 
     def fct_frequency(self):
-
-        f_stats = self.statistics['frequency']
-        distribution = getattr(np.random, f_stats['distribution'].lower())
-        average = f_stats['average']
-        return distribution(average)
+        dist_name, dist_params = self.get_statistical_params(self.statistics['frequency'])
+        return round(sample_value(dist_name, **dist_params))
 
     def fct_duration_intensity_temperature(self):
-
-        subtype = chooser(self.statistics['subtype'], 'penetration')
-
-        d_stats = self.statistics['subtype'][subtype]['duration']
-        i_stats = self.statistics['subtype'][subtype]['intensity']
-
-        dist = getattr(np.random, d_stats['distribution'].lower())
-        mean = np.log(pd.Timedelta(d_stats['average']).total_seconds()) - 0.5
-
-        duration = int(pd.Timedelta(seconds=dist(mean=mean)).total_seconds())
-
-        dist = getattr(np.random, i_stats['distribution'].lower())
-        low = i_stats['low']
-        high = i_stats['high']
-
-        intensity = dist(low=low, high=high)
-        temperature = self.statistics['subtype'][subtype]['temperature']
-
+        self.subtype = chooser(self.statistics['subtype'], 'penetration')
+        d_dist, d_stats = self.get_statistical_params(self.statistics['subtype'][self.subtype]['duration'])
+        duration = round(sample_value(d_dist, **d_stats))
+        i_dist, i_stats = self.get_statistical_params(self.statistics['subtype'][self.subtype]['intensity'])
+        intensity = sample_value(i_dist, **i_stats)
+        temperature = self.statistics['subtype'][self.subtype]['temperature']
         return duration, intensity, temperature
 
     def simulate(self, consumption, discharge=None, users=None, ind_enduse=None, pattern_num=1, day_num=0, total_days=1, simulate_discharge=False, spillover=False):
@@ -665,27 +587,14 @@ class Shower(EndUse):
     wastewater_type: str = "greywater"
 
     def fct_frequency(self, age=None):
-
-        f_stats = self.statistics['frequency']
-        distribution = getattr(np.random, f_stats['distribution'].lower())
-        n = f_stats['n']
-        p = f_stats['p'][age]
-
-        return distribution(n, p)
+        dist_name, dist_params = self.get_statistical_params(self.statistics['frequency'], age=age)
+        return round(sample_value(dist_name, **dist_params))
 
     def fct_duration_intensity_temperature(self, age=None):
-
-        d_stats = self.statistics['duration']
-        distribution = getattr(np.random, d_stats['distribution'].lower())
-        df = to_timedelta(d_stats['df'][age])
-
-        df = int(df.total_seconds() / 60)
-        duration = round(distribution(df))
-        duration = int(pd.Timedelta(minutes=duration).total_seconds())
-
+        d_dist, d_stats = self.get_statistical_params(self.statistics['duration'], age=age)
+        duration = round(sample_value(d_dist, **d_stats))
         intensity = self.statistics['subtype'][self.name]['intensity']
         temperature = self.statistics['temperature']
-
         return duration, intensity, temperature
 
     def calculate_discharge(self, discharge, start, duration, intensity, temperature_fraction, j, ind_enduse, pattern_num, spillover=False):
@@ -766,13 +675,8 @@ class WashingMachine(EndUse):
     wastewater_type: str = "blackwater"
 
     def fct_frequency(self, numusers=None):
-
-        f_stats = self.statistics['frequency']
-        distribution = getattr(np.random, f_stats['distribution'].lower())
-
-        df = pd.Series(f_stats['average'])
-        average = df[str(numusers)] * numusers
-        return distribution(average)
+        dist_name, dist_params = self.get_statistical_params(self.statistics['frequency'], numusers=numusers)  # TODO: change the frequency config because it no longer multiplies by numusers.
+        return round(sample_value(dist_name, **dist_params))
 
     def fct_duration_pattern(self, start=None):
         pattern = self.statistics['enduse_pattern']
@@ -803,10 +707,8 @@ class WashingMachine(EndUse):
         if isinstance(discharge_temperature, (int, float)):
             discharge_temperatures = [discharge_temperature] * len(cycle_times)
         elif isinstance(discharge_temperature, dict):
-            dist = getattr(np.random, discharge_temperature['distribution'].lower())
-            low = discharge_temperature['low']
-            high = discharge_temperature['high']
-            discharge_temperatures = dist(low=low, high=high, size=len(cycle_times)).tolist()
+            dist_name, dist_params = self.get_statistical_params(discharge_temperature)
+            discharge_temperatures = [sample_value(dist_name, **dist_params) for __ in cycle_times]
         else:
             raise ValueError("Discharge temperature type not implemented.")
 
@@ -879,12 +781,8 @@ class Wc(EndUse):
         self.discharge_events = []
 
     def fct_frequency(self, age=None, gender=None):
-        f_stats = self.statistics['frequency']
-        distribution = getattr(np.random, f_stats['distribution'].lower())
-
-        average = f_stats['average'][age][gender]
-
-        return distribution(average)
+        dist_name, dist_params = self.get_statistical_params(self.statistics['frequency'], age=age, gender=gender)
+        return round(sample_value(dist_name, **dist_params))
 
     def fct_duration_intensity_temperature(self):
 
@@ -894,8 +792,6 @@ class Wc(EndUse):
         intensity = self.statistics['intensity']
         temperature = self.statistics['temperature']
         average = to_timedelta(self.statistics['subtype'][self.name]['duration'])
-
-        # dist = duration_decorator(getattr(np.random, d_stats['distribution'].lower()))
 
         # add water savings option
         if flush_interuption:

--- a/pysimdeum/core/statistics.py
+++ b/pysimdeum/core/statistics.py
@@ -73,10 +73,3 @@ class Statistics:
             return [self._convert_to_dict(v) for v in data]
         else:
             return data
-    
-def main():
-    print(DATA_DIR)
-    stats = Statistics()
-
-if __name__ == '__main__':
-    main()

--- a/pysimdeum/core/statistics.py
+++ b/pysimdeum/core/statistics.py
@@ -8,15 +8,26 @@ from pysimdeum.data import DATA_DIR
 @dataclass
 class Statistics:
     """Statistics dataclass that contains all the relevant statistical information for pysimdeum."""
+    # Class attribute: same pointer for all instances.
+    expected_end_uses = [
+        'BathroomTap',
+        'Bathtub',
+        'Dishwasher',
+        'KitchenTap',
+        'OutsideTap',
+        'Shower',
+        'WashingMachine',
+        'Wc',
+    ]
 
-    country: str = 'NL'   
+    # Dataclass attribute (note the type declaration): unique for each instance.
+    country: str = 'NL'
     household: dict = field(default_factory=dict)
     diurnal_pattern: dict = field(default_factory=dict)
     end_uses: dict = field(default_factory=dict)
     statisticsdir: str = ""  # TODO: Find good solution for this dirty statistics file workaround
 
     def __post_init__(self):
-        
         # Check if pointing to a custom statistics directory or a country in the repository
         if os.path.isdir(self.country):
             self.statisticsdir = self.country
@@ -35,36 +46,17 @@ class Statistics:
         # load end-uses:
         self.end_uses = dict()
         path2end_use = os.path.join(self.statisticsdir, 'end_uses')
+        for end_use_name in self.expected_end_uses:
+            with open(os.path.join(path2end_use, f'{end_use_name}.toml'), 'r') as end_use_file:
+                self.end_uses[end_use_name] = self._convert_to_dict(toml.load(end_use_file))
 
-        bathtub_file = os.path.join(path2end_use, 'Bathtub.toml')
-        brtap_file = os.path.join(path2end_use, 'BathroomTap.toml')
-        dishwasher_file = os.path.join(path2end_use, 'Dishwasher.toml')
-        kitchen_tap_file = os.path.join(path2end_use, 'KitchenTap.toml')
-        outside_tap_file = os.path.join(path2end_use, 'OutsideTap.toml')
-        shower_file = os.path.join(path2end_use, 'Shower.toml')
-        washing_machine_file = os.path.join(path2end_use, 'WashingMachine.toml')
-        wc_file = os.path.join(path2end_use, 'Wc.toml')
-
-        self.end_uses['Wc'] = toml.load(open(wc_file, 'r'))
-        self.end_uses['Bathtub'] = toml.load(open(bathtub_file, 'r'))
-        self.end_uses['BathroomTap'] = toml.load(open(brtap_file, 'r'))
-        self.end_uses['Dishwasher'] = self._convert_to_dict(toml.load(open(dishwasher_file, 'r')))
-        self.end_uses['KitchenTap'] = toml.load(open(kitchen_tap_file, 'r'))
-        self.end_uses['OutsideTap'] = toml.load(open(outside_tap_file, 'r'))
-        self.end_uses['Shower'] = toml.load(open(shower_file, 'r'))
-        self.end_uses['WashingMachine'] = self._convert_to_dict(toml.load(open(washing_machine_file, 'r')))
-
-        # Pattern
-        self._initialize_patterns()
-
-    def _initialize_patterns(self):
-        self.end_uses['WashingMachine']['daily_pattern'] = complex_daily_pattern(self.end_uses['WashingMachine'])
-        self.end_uses['WashingMachine']['enduse_pattern'] = complex_enduse_pattern(self.end_uses['WashingMachine'])
-        self.end_uses['WashingMachine']['discharge_pattern'] = complex_discharge_pattern(self.end_uses['WashingMachine'], self.end_uses['WashingMachine']['enduse_pattern'])
-        self.end_uses['Dishwasher']['daily_pattern'] = complex_daily_pattern(self.end_uses['Dishwasher'])
-        self.end_uses['Dishwasher']['enduse_pattern'] = complex_enduse_pattern(self.end_uses['Dishwasher'])
-        self.end_uses['Dishwasher']['discharge_pattern'] = complex_discharge_pattern(self.end_uses['Dishwasher'], self.end_uses['Dishwasher']['enduse_pattern'])
-        self.end_uses['KitchenTap']['daily_pattern'] = complex_daily_pattern(self.end_uses['KitchenTap'], freq='15Min')
+            # Initialize special patterns
+            if end_use_name == 'KitchenTap':
+                self.end_uses[end_use_name]['daily_pattern'] = complex_daily_pattern(self.end_uses[end_use_name], freq='15Min')
+            elif end_use_name in ['WashingMachine', 'Dishwasher']:
+                self.end_uses[end_use_name]['daily_pattern'] = complex_daily_pattern(self.end_uses[end_use_name])
+                self.end_uses[end_use_name]['enduse_pattern'] = complex_enduse_pattern(self.end_uses[end_use_name])
+                self.end_uses[end_use_name]['discharge_pattern'] = complex_discharge_pattern(self.end_uses[end_use_name], self.end_uses[end_use_name]['enduse_pattern'])
 
     def _convert_to_dict(self, data):
         """Convert dict subclasses to native Python `dict` for `pickle` to work.

--- a/pysimdeum/core/statistics.py
+++ b/pysimdeum/core/statistics.py
@@ -3,7 +3,7 @@ import toml
 from dataclasses import dataclass, field
 from pysimdeum.utils.patterns import complex_daily_pattern, complex_enduse_pattern, complex_discharge_pattern
 from pysimdeum.data import DATA_DIR
-import pickle
+
 
 @dataclass
 class Statistics:

--- a/pysimdeum/core/statistics.py
+++ b/pysimdeum/core/statistics.py
@@ -67,6 +67,11 @@ class Statistics:
         self.end_uses['KitchenTap']['daily_pattern'] = complex_daily_pattern(self.end_uses['KitchenTap'], freq='15Min')
 
     def _convert_to_dict(self, data):
+        """Convert dict subclasses to native Python `dict` for `pickle` to work.
+
+        `toml.load()` returns `DynamicInlineTableDict`, a subclass of `dict`.
+        It looks and behaves the same, until `pickle` tries to serialize it and fails.
+        """
         if isinstance(data, dict):
             return {k: self._convert_to_dict(v) for k, v in data.items()}
         elif isinstance(data, list):

--- a/pysimdeum/data/NL/end_uses/Dishwasher.toml
+++ b/pysimdeum/data/NL/end_uses/Dishwasher.toml
@@ -34,9 +34,9 @@ temperature = 10
 [frequency]
     distribution = 'Poisson'
     [frequency.average]
-        1 = 0.2143  # [1/day]
-        2 = 0.2286
-        3 = 0.1857
-        4 = 0.2000
-        5 = 0.1429
+        1 = 0.2143  # cycles per day per household
+        2 = 0.4572  # 0.2286 cycles per day per person
+        3 = 0.5571
+        4 = 0.8000
+        5 = 0.7145
 

--- a/pysimdeum/data/NL/end_uses/KitchenTap.toml
+++ b/pysimdeum/data/NL/end_uses/KitchenTap.toml
@@ -61,7 +61,7 @@ distribution = 'Negative_binomial'
 
         [subtype.dishes.discharge_intensity]
             distribution = 'Uniform'
-            low = 0.0
+            low = 0.01
             high = 0.25
 
     [subtype.washing_hands]
@@ -80,7 +80,7 @@ distribution = 'Negative_binomial'
 
         [subtype.washing_hands.discharge_intensity]
             distribution = 'Uniform'
-            low = 0.0
+            low = 0.01
             high = 0.167
 
     [subtype.other]
@@ -99,5 +99,5 @@ distribution = 'Negative_binomial'
 
         [subtype.other.discharge_intensity]
             distribution = 'Uniform'
-            low = 0.0
+            low = 0.01
             high = 0.167

--- a/pysimdeum/data/NL/end_uses/WashingMachine.toml
+++ b/pysimdeum/data/NL/end_uses/WashingMachine.toml
@@ -35,10 +35,10 @@ temperature = 10
 [frequency]
     distribution = 'Poisson'
     [frequency.average]
-        1 = 0.32  # [1/day]
-        2 = 0.29
-        3 = 0.29
-        4 = 0.27
-        5 = 0.29
+        1 = 0.32  # cycles per day per household
+        2 = 0.58  # 0.29 cycles per day per person
+        3 = 0.87
+        4 = 1.08
+        5 = 1.45
 
 # through subtypes different washing machine patterns (washing programs) could be constructed in the future

--- a/pysimdeum/data/UK/end_uses/Dishwasher.toml
+++ b/pysimdeum/data/UK/end_uses/Dishwasher.toml
@@ -37,9 +37,9 @@ temperature = 10
 [frequency]
     distribution = 'Poisson'
     [frequency.average]
-        1 = 0.1286  # [1/day]
-        2 = 0.1643
-        3 = 0.1476
-        4 = 0.1536
-        5 = 0.1371
+        1 = 0.1286  # cycles per day per household
+        2 = 0.3286  # 0.1643 cycles per day per person
+        3 = 0.4428
+        4 = 0.6144
+        5 = 0.6855
 

--- a/pysimdeum/data/UK/end_uses/KitchenTap.toml
+++ b/pysimdeum/data/UK/end_uses/KitchenTap.toml
@@ -63,7 +63,7 @@ distribution = 'Negative_binomial'
 
         [subtype.dishes.discharge_intensity]
             distribution = 'Uniform'
-            low = 0.0
+            low = 0.01
             high = 0.25
 
     [subtype.washing_hands]
@@ -82,7 +82,7 @@ distribution = 'Negative_binomial'
 
         [subtype.washing_hands.discharge_intensity]
             distribution = 'Uniform'
-            low = 0.0
+            low = 0.01
             high = 0.167
 
     [subtype.other]
@@ -101,5 +101,5 @@ distribution = 'Negative_binomial'
 
         [subtype.other.discharge_intensity]
             distribution = 'Uniform'
-            low = 0.0
+            low = 0.01
             high = 0.167

--- a/pysimdeum/data/UK/end_uses/WashingMachine.toml
+++ b/pysimdeum/data/UK/end_uses/WashingMachine.toml
@@ -36,10 +36,10 @@ temperature = 40
 [frequency]
     distribution = 'Poisson'
     [frequency.average]
-        1 = 0.36  # [1/day]
-        2 = 0.29
-        3 = 0.29
-        4 = 0.26
-        5 = 0.21
+        1 = 0.36  # cycles per day per household
+        2 = 0.58  # 0.29 cycles per day per person
+        3 = 0.87
+        4 = 1.04
+        5 = 1.05
 
 # through subtypes different washing machine patterns (washing programs) could be constructed in the future

--- a/pysimdeum/utils/patterns.py
+++ b/pysimdeum/utils/patterns.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas as pd
 
 
-def sample_start_time(prob_joint: np.ndarray, day_num: int, duration: int, previous_events: list, offset: int=0) -> (int, int):
+def sample_start_time(prob_joint: np.ndarray, day_num: int, duration: int, previous_events: list, offset: int=0) -> tuple[int, int]:
     """
     Samples a valid start time for an event, ensuring no overlap with previous events
     and no start within duration before the last sampled start time.
@@ -17,7 +17,7 @@ def sample_start_time(prob_joint: np.ndarray, day_num: int, duration: int, previ
     Returns:
         The pair (tuple) of the sampled start time and calculated end time.
     """
-    max_attempts = 10000  # Define a maximum number of attempts to prevent infinite loops
+    max_attempts = 100000  # Define a maximum number of attempts to prevent infinite loops
     for __ in range(max_attempts):
         start_index = np.random.choice(len(prob_joint), p=prob_joint)
         start = start_index + int(pd.to_timedelta('1 day').total_seconds()) * day_num

--- a/pysimdeum/utils/probability.py
+++ b/pysimdeum/utils/probability.py
@@ -177,7 +177,7 @@ def sample_value(dist_name: str, **kwargs) -> Union[float, int]:
                     --------------------|-----------------------|------------------
                     Poisson             | `average`             | Used as lambda.
                     Negative Binomial   | `average`, `sigma`    | Converted to r and p.
-                    Lognormal           | average               | Converted to mean = log(average) - 0.5.
+                    Lognormal           | `average`             | Converted to mean = log(average) - 0.5.
 
     Returns:
         A scalar, sampled at random from the specified distribution.

--- a/pysimdeum/utils/probability.py
+++ b/pysimdeum/utils/probability.py
@@ -44,24 +44,6 @@ def chooser(data: Union[pd.Series, pd.DataFrame], myproperty: str=''):
     return choose
 
 
-def duration_decorator(func):
-    """Decorator function for duration.
-
-    This decorator transforms duration from timedelta to total seconds, then performs the function on the
-    seconds (e.g. fct_duration for generating durations from a probability distribution), afterwards  it transforms
-    the output back to a pd.Timedelta object."""
-
-    def wrapper(*args, **kwargs):
-
-        args = map(lambda x: (pd.Timedelta(x)).total_seconds(), args)
-        kwargs = {k: pd.Timedelta(v).total_seconds() for k, v in kwargs.items()}
-        result = func(*args, **kwargs)
-        result = to_timedelta(round(result))
-        return result
-
-    return wrapper
-
-
 def normalize(pdf: Union[np.ndarray, pd.Series]) -> Union[np.ndarray, pd.Series]:
     """Normalize probability density function (pdf).
 

--- a/pysimdeum/utils/probability.py
+++ b/pysimdeum/utils/probability.py
@@ -1,8 +1,15 @@
+import inspect
 import pandas as pd
 import numpy as np
 from typing import Union
 from scipy.stats import truncnorm
 from scipy.optimize import minimize
+
+# Use a better generator than legacy.
+# Instanciate once for the module.
+# Requires numpy >= 1.17.
+RNG = np.random.default_rng()
+
 
 def chooser(data: Union[pd.Series, pd.DataFrame], myproperty: str=''):
     """Function to choose elements from a pd.Series randomly, which consists of keys representing the elements and probabilities as values [-> Statistics object].
@@ -172,3 +179,70 @@ def optimise_probabilities(starting_probs, total_population, total_households, h
         raise ValueError(f"Optimisation failed: {result.message}")
 
     return result.x
+
+
+def sample_value(dist_name: str, **kwargs) -> Union[float, int]:
+    """Generate a single value from the named distribution using the provided parameters.
+
+    Args:
+        dist_name:  The name of the distribution. It must be supported by numpy.random.Generator.
+                    Please see: https://numpy.org/doc/stable/reference/random/generator.html#distributions
+        **kwargs:   Parameters of the distribution. Names should either correspond to the parameter
+                    names of the distributions in numpy.random.Generator, or fit in the following list
+                    of supported exceptions:
+
+                    Distribution        | Accepted parameter    | Comment
+                    --------------------|-----------------------|------------------
+                    Poisson             | `average`             | Used as lambda.
+                    Negative Binomial   | `average`, `sigma`    | Converted to r and p.
+                    Lognormal           | average               | Converted to mean = log(average) - 0.5.
+
+    Returns:
+        A scalar, sampled at random from the specified distribution.
+        All time deltas are expressed in seconds.
+
+    Raises:
+        ValueError: if the distribution is not supported or the parameters don't match.
+    """
+    dist_name = dist_name.lower()
+    # Convert all arguments to float, incl. durations to number of seconds.
+    float_kwargs = {}
+    for k, v in kwargs.items():
+        if isinstance(v, str):
+            try:
+                float_kwargs[k] = float(v)
+            except ValueError:
+                float_kwargs[k] = pd.Timedelta(v).total_seconds()
+        else:
+            float_kwargs[k] = float(v)
+
+    # Start with exceptions.
+    if dist_name == 'poisson' and 'average' in float_kwargs:
+        return RNG.poisson(float_kwargs['average'])
+
+    if dist_name == 'negative_binomial' and 'average' in float_kwargs and 'sigma' in kwargs:
+        # p-formula, consistent with both Mirjam's orginal implementation and Wikipedia.
+        p = float_kwargs['average'] / kwargs['sigma'] ** 2
+        # r-formula, using Mirjam's implementation but equivalent to: r = (average ** 2) / (sigma ** 2 - average)
+        r = p * float_kwargs['average'] / (1 - p)
+        return RNG.negative_binomial(r, p)
+
+    if dist_name == 'lognormal' and 'average' in float_kwargs:
+        return RNG.lognormal(mean=np.log(float_kwargs['average']) - 0.5, sigma=1.)
+
+    try:
+        dist_function = getattr(RNG, dist_name)
+    except AttributeError:
+        raise ValueError(f'Unsupported distribution: {dist_name}')
+
+    func_params = [
+        param.name
+        for param in inspect.signature(dist_function).parameters.values()
+    ]
+    if all(x in func_params for x in float_kwargs):
+        return dist_function(**float_kwargs)
+    else:
+        raise ValueError(
+            f"{dist_name} distribution expects parameters {', '.join(func_params)}"
+            f"but received {', '.join(float_kwargs)}."
+        )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 matplotlib
-numpy
+numpy >= 1.17
 pandas
 toml
 xarray

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,18 +3,17 @@ name = pysimdeum
 version = attr: pysimdeum.__version__
 description = A stochastic water demand end-use model in Python
 author = David B. Steffelbauer
-author-email = david.steffelbauer@kompetenz-wasser.de
+author_email = david.steffelbauer@kompetenz-wasser.de
 maintainer = Bram Hillebrand
-maintainer-email = bram.hillebrand@kwrwater.nl
+maintainer_email = bram.hillebrand@kwrwater.nl
 long_description = file: README.md
 long_description_content_type = text/markdown
-license = "EUPL"
+license = "EUPL-1.2"
 classifiers =
     Development Status :: 4 - Beta
     Intended Audience :: Developers
     Topic :: Scientific/Engineering
-    License :: OSI Approved :: European Union Public Licence 1.2 (EUPL 1.2)
-    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3
     Typing :: Typed
 url = https://github.com/KWR-Water/pysimdeum
 project_urls =
@@ -25,10 +24,10 @@ keyword =
     stochastic
 
 [options]
-python_requires_python = >3.8
+python_requires_python = >=3.10
 install_requires =
     matplotlib
-    numpy
+    numpy >= 1.17
     pandas
     toml
     xarray

--- a/testing/core/test_end_use.py
+++ b/testing/core/test_end_use.py
@@ -1,0 +1,218 @@
+"""
+Tests for pysimdeum.core.end_use using the real NL statistics files.
+
+No mocking — all end-use classes are instantiated with data loaded by
+Statistics('NL') from the installed pysimdeum package.
+"""
+
+import pytest
+import numpy as np
+import pandas as pd
+from pysimdeum.core.statistics import Statistics
+from pysimdeum.core.end_use import (
+    EndUse,
+    BathroomTap,
+    Bathtub,
+    Dishwasher,
+    KitchenTap,
+    OutsideTap,
+    NormalShower,
+    FancyShower,
+    WashingMachine,
+    WcNormal,
+    WcNormalSave,
+    WcNew,
+    WcNewSave,
+)
+
+
+N_PTS = 24 * 60 * 60  # One point per second over a day, 86400 points total.
+ALL_END_USES = [
+    pytest.param(Bathtub,        'Bathtub',        id='Bathtub'),
+    pytest.param(BathroomTap,    'BathroomTap',    id='BathroomTap'),
+    pytest.param(Dishwasher,     'Dishwasher',     id='Dishwasher'),
+    pytest.param(KitchenTap,     'KitchenTap',     id='KitchenTap'),
+    pytest.param(OutsideTap,     'OutsideTap',     id='OutsideTap'),
+    pytest.param(NormalShower,   'Shower',         id='NormalShower'),
+    pytest.param(FancyShower,    'Shower',         id='FancyShower'),
+    pytest.param(WashingMachine, 'WashingMachine', id='WashingMachine'),
+    pytest.param(WcNormal,       'Wc',             id='WcNormal'),
+    pytest.param(WcNormalSave,   'Wc',             id='WcNormalSave'),
+    pytest.param(WcNew,          'Wc',             id='WcNew'),
+    pytest.param(WcNewSave,      'Wc',             id='WcNewSave'),
+]
+
+
+@pytest.fixture(scope='module')
+def nl_stats():
+    """Load NL statistics once for all tests in this module."""
+    return Statistics('NL')
+
+
+class TestParentEndUseClass:
+    """The class methods inherited from EndUse work as intended."""
+
+    @pytest.mark.parametrize('offset, expected', [
+        pytest.param(0, pd.Timedelta(), id='null_offset'),
+        pytest.param('2 Hours', pd.Timedelta(hours=2), id='hours_offset'),
+        pytest.param('20 Minutes', pd.Timedelta(minutes=2), id='minutes_offset'),
+    ])
+    def test_construction_and_offset(self, offset, expected):
+        """Instantiation sets the offset."""
+        end_use = EndUse(statistics={'offset': offset})
+        assert end_use.offset == expected
+
+    def test_init_consumption(self):
+        """init_consumption creates a zero-filled DataFrame with correct shape."""
+        end_use = EndUse(statistics={'offset': 100})
+        # Omitting users raises an exception.
+        with pytest.raises(Exception):
+            end_use.init_consumption()
+
+        users = ['a', 'b', 'c']
+        df = end_use.init_consumption(users=users)
+        assert isinstance(df, pd.DataFrame)
+        assert df.shape == (N_PTS, len(users))
+        assert (df == 0).all().all()
+        assert df.name == 'EndUse'
+        assert list(df.columns) == ['user_1', 'user_2', 'user_3']
+
+    def test_probability_distribution(self):
+        """Base usage_probability returns a valid normalised distribution."""
+        prob = EndUse.usage_probability() 
+        assert isinstance(prob, pd.Series)
+        assert len(prob) == N_PTS
+        assert prob.sum() == pytest.approx(1.0)
+        assert (prob >= 0).all()
+
+
+class TestChildEndUseClasses:
+    """All end-use classes construct from NL statistics without error."""
+
+    @pytest.mark.parametrize('cls, stats_key', ALL_END_USES)
+    def test_construction_and_offset(self, nl_stats, cls, stats_key):
+        """Instantiation sets a non-negative integer offset."""
+        end_use = cls(statistics=nl_stats.end_uses[stats_key])
+        assert isinstance(end_use, cls)
+        assert isinstance(end_use.offset, int)
+        assert end_use.offset == nl_stats.end_uses[stats_key]['offset']
+
+    @pytest.mark.parametrize('cls, stats_key', [
+        pytest.param(BathroomTap, 'BathroomTap', id='BathroomTap'),
+        pytest.param(OutsideTap,  'OutsideTap',  id='OutsideTap'),
+    ])
+    def test_no_arg_frequency(self, nl_stats, cls, stats_key):
+        """End-uses whose frequency takes no arguments."""
+        end_use = cls(statistics=nl_stats.end_uses[stats_key])
+        freq = end_use.fct_frequency()
+        assert isinstance(freq, (int, np.integer))
+        assert freq >= 0
+
+    @pytest.mark.parametrize('cls, stats_key, age_path', [
+        pytest.param(Bathtub,      'Bathtub', ['frequency', 'average'], id='Bathtub'),
+        pytest.param(NormalShower, 'Shower',  ['frequency', 'p'],       id='NormalShower'),
+        pytest.param(FancyShower,  'Shower',  ['frequency', 'p'],       id='FancyShower'),
+    ])
+    def test_age_based_frequency(self, nl_stats, cls, stats_key, age_path):
+        """End-uses whose frequency depends on user age."""
+        end_use = cls(statistics=nl_stats.end_uses[stats_key])
+        d = end_use.statistics
+        for key in age_path:
+            d = d[key]
+
+        for age in d:
+            freq = end_use.fct_frequency(age=age)
+            assert isinstance(freq, (int, np.integer))
+            assert freq >= 0
+
+    @pytest.mark.parametrize('cls, stats_key', [
+        pytest.param(Dishwasher,     'Dishwasher',     id='Dishwasher'),
+        pytest.param(KitchenTap,     'KitchenTap',     id='KitchenTap'),
+        pytest.param(WashingMachine, 'WashingMachine', id='WashingMachine'),
+    ])
+    def test_numusers_frequency(self, nl_stats, cls, stats_key):
+        """End-uses whose frequency depends on the number of household users."""
+        end_use = cls(statistics=nl_stats.end_uses[stats_key])
+        for n_str in end_use.statistics['frequency']['average']:
+            freq = end_use.fct_frequency(numusers=int(n_str))
+            assert isinstance(freq, (int, np.integer))
+            assert freq >= 0
+
+    @pytest.mark.parametrize('cls', [
+        pytest.param(WcNormal,     id='WcNormal'),
+        pytest.param(WcNormalSave, id='WcNormalSave'),
+        pytest.param(WcNew,        id='WcNew'),
+        pytest.param(WcNewSave,    id='WcNewSave'),
+    ])
+    def test_wc_frequency(self, nl_stats, cls):
+        """WC frequency depends on both age and gender."""
+        end_use = cls(statistics=nl_stats.end_uses['Wc'])
+        age_dict = end_use.statistics['frequency']['average']
+        for age in age_dict:
+            for gender in age_dict[age]:
+                freq = end_use.fct_frequency(age=age, gender=gender)
+                assert isinstance(freq, (int, np.integer))
+                assert freq >= 0
+
+    def test_bathtub_separate_methods(self, nl_stats):
+        """Bathtub exposes duration, intensity, temperature as separate calls."""
+        end_use = Bathtub(statistics=nl_stats.end_uses['Bathtub'])
+        duration = end_use.fct_duration()
+        intensity = end_use.fct_intensity()
+        temperature = end_use.temperature()
+        assert isinstance(duration, int) and duration > 0
+        assert isinstance(intensity, (int, float)) and intensity > 0
+        assert isinstance(temperature, (int, float))
+
+    @pytest.mark.parametrize('cls, stats_key', [
+        pytest.param(BathroomTap, 'BathroomTap', id='BathroomTap'),
+        pytest.param(KitchenTap,  'KitchenTap',  id='KitchenTap'),
+        pytest.param(OutsideTap,  'OutsideTap',  id='OutsideTap'),
+    ])
+    def test_chooser_based(self, nl_stats, cls, stats_key):
+        """End-uses that internally pick a subtype via chooser()."""
+        end_use = cls(statistics=nl_stats.end_uses[stats_key])
+        duration, intensity, temperature = end_use.fct_duration_intensity_temperature()
+        assert isinstance(duration, (int, float)) and duration >= 0
+        assert isinstance(intensity, (int, float)) and intensity > 0
+        assert isinstance(temperature, (int, float))
+
+    @pytest.mark.parametrize('cls', [
+        pytest.param(NormalShower, id='NormalShower'),
+        pytest.param(FancyShower,  id='FancyShower'),
+    ])
+    def test_shower_age_based(self, nl_stats, cls):
+        """Shower duration/intensity/temperature for every available age key."""
+        end_use = cls(statistics=nl_stats.end_uses['Shower'])
+        for age in end_use.statistics['duration']['df']:
+            duration, intensity, temperature = end_use.fct_duration_intensity_temperature(age=age)
+            assert isinstance(duration, (int, float)) and duration >= 0
+            assert isinstance(intensity, (int, float)) and intensity > 0
+            assert isinstance(temperature, (int, float))
+
+    @pytest.mark.parametrize('cls', [
+        pytest.param(WcNormal,     id='WcNormal'),
+        pytest.param(WcNormalSave, id='WcNormalSave'),
+        pytest.param(WcNew,        id='WcNew'),
+        pytest.param(WcNewSave,    id='WcNewSave'),
+    ])
+    def test_wc(self, nl_stats, cls):
+        """WC returns fixed duration, intensity, temperature."""
+        end_use = cls(statistics=nl_stats.end_uses['Wc'])
+        duration, intensity, temperature = end_use.fct_duration_intensity_temperature()
+        assert isinstance(duration, int) and duration > 0
+        assert isinstance(intensity, (int, float)) and intensity > 0
+        assert isinstance(temperature, (int, float))
+
+    @pytest.mark.parametrize('cls, stats_key', [
+        pytest.param(Dishwasher,     'Dishwasher',     id='Dishwasher'),
+        pytest.param(WashingMachine, 'WashingMachine', id='WashingMachine'),
+    ])
+    def test_pattern_shape_and_values(self, nl_stats, cls, stats_key):
+        """Dishwasher / WashingMachine return a TimedeltaIndex pattern."""
+        end_use = cls(statistics=nl_stats.end_uses[stats_key])
+        pattern = end_use.fct_duration_pattern()
+        assert isinstance(pattern, pd.Series)
+        assert len(pattern) > 0
+        assert (pattern >= 0).all()
+        assert isinstance(pattern.index, pd.TimedeltaIndex)

--- a/testing/core/test_end_use.py
+++ b/testing/core/test_end_use.py
@@ -63,7 +63,15 @@ def nl_stats():
 @pytest.fixture(scope="module")
 def end_use():
     """Minimal EndUse (only needs a valid 'offset' to construct)."""
-    return EndUse(statistics={"offset": "0s"})
+    mock_stats = {
+        'offset': '0s',
+        'frequency': {
+            'distribution': 'Uniform',
+            'low': 1,
+            'high': 2,
+        }
+    }
+    return EndUse(statistics=mock_stats)
 
 
 class TestParentEndUseClass:
@@ -130,10 +138,14 @@ class TestParentEndUseClass:
         pytest.param(AGE_GENDER_CONFIG, {"age": "nonexistent"}, id="invalid-age"),
         pytest.param(NUMUSERS_CONFIG, {"numusers": 99}, id="invalid-numusers"),
     ])
-    def test_raises_on_invalid_input(self, end_use, dist_config, call_kwargs):
+    def test_get_statistical_params_fail(self, end_use, dist_config, call_kwargs):
         """Missing or mismatched keys raise KeyError."""
         with pytest.raises(KeyError):
             end_use.get_statistical_params(dist_config, **call_kwargs)
+
+    def test_fct_frequency(self, end_use):
+        res = {end_use.fct_frequency() for __ in range(10)}
+        assert res == {1, 2}
 
 
 class TestChildEndUseClasses:

--- a/testing/core/test_end_use.py
+++ b/testing/core/test_end_use.py
@@ -69,7 +69,7 @@ def end_use():
             'distribution': 'Uniform',
             'low': 1,
             'high': 2,
-        }
+        },
     }
     return EndUse(statistics=mock_stats)
 
@@ -146,6 +146,50 @@ class TestParentEndUseClass:
     def test_fct_frequency(self, end_use):
         res = {end_use.fct_frequency() for __ in range(10)}
         assert res == {1, 2}
+
+    @pytest.mark.parametrize("subtype_config, exp_d_range, exp_i_range, exp_t_range, exp_subtypes", [
+        pytest.param(
+            {
+                'subtype': {
+                    'test': {
+                        'penetration': 100,
+                        'temperature': 23,
+                        'duration': {'distribution': 'Lognormal', 'average': '1 Minute'},
+                        'intensity': {'distribution': 'Uniform', 'low': 0.1, 'high': 0.5},
+                    },
+                },
+            },
+            [0, 6000], [0.1, 0.5], [23], ['test'],
+            id="one-subtype"
+        ),
+        pytest.param(
+            {
+                'subtype': {
+                    'subtype1': {
+                        'penetration': 80,
+                        'temperature': 23,
+                        'duration': {'distribution': 'Lognormal', 'average': '1 Minute'},
+                        'intensity': {'distribution': 'Uniform', 'low': 0.1, 'high': 0.5},
+                    },
+                    'subtype2': {
+                        'penetration': 20,
+                        'temperature': 10,
+                        'duration': {'distribution': 'Lognormal', 'average': '2 Minutes'},
+                        'intensity': {'distribution': 'Uniform', 'low': 0.1, 'high': 0.3},
+                    },
+                },
+            },
+            [0, 12000], [0.1, 0.5], [10, 23], ['subtype1', 'subtype2'],
+            id="two-subtypes"
+        ),
+    ])
+    def test_fct_duration_intensity_temperature(self, subtype_config, exp_d_range, exp_i_range, exp_t_range, exp_subtypes):
+        end_use = EndUse(statistics=dict({'offset': '0s'}, **subtype_config))
+        duration, intensity, temperature = end_use.fct_duration_intensity_temperature()
+        assert exp_d_range[0] < duration < exp_d_range[1]
+        assert exp_i_range[0] <= intensity <= exp_i_range[1]
+        assert temperature in exp_t_range
+        assert end_use.subtype in exp_subtypes  # Side-effect
 
 
 class TestChildEndUseClasses:

--- a/testing/core/test_end_use.py
+++ b/testing/core/test_end_use.py
@@ -49,37 +49,41 @@ def nl_stats():
     return Statistics('NL')
 
 
+@pytest.fixture(scope="module")
+def end_use():
+    """Minimal EndUse (only needs a valid 'offset' to construct)."""
+    return EndUse(statistics={"offset": "0s"})
+
+
 class TestParentEndUseClass:
     """The class methods inherited from EndUse work as intended."""
 
     @pytest.mark.parametrize('offset, expected', [
-        pytest.param(0, pd.Timedelta(), id='null_offset'),
-        pytest.param('2 Hours', pd.Timedelta(hours=2), id='hours_offset'),
-        pytest.param('20 Minutes', pd.Timedelta(minutes=2), id='minutes_offset'),
+        pytest.param(0, 0, id='null_offset'),
+        pytest.param('2 Hours', 7200, id='hours_offset'),
+        pytest.param('20 Minutes', 1200, id='minutes_offset'),
     ])
     def test_construction_and_offset(self, offset, expected):
         """Instantiation sets the offset."""
         end_use = EndUse(statistics={'offset': offset})
         assert end_use.offset == expected
 
-    def test_init_consumption(self):
+    def test_init_consumption(self, end_use):
         """init_consumption creates a zero-filled DataFrame with correct shape."""
-        end_use = EndUse(statistics={'offset': 100})
         # Omitting users raises an exception.
-        with pytest.raises(Exception):
-            end_use.init_consumption()
+        with pytest.raises(KeyError):
+            end_use.init_consumption(users=[])
 
         users = ['a', 'b', 'c']
         df = end_use.init_consumption(users=users)
         assert isinstance(df, pd.DataFrame)
         assert df.shape == (N_PTS, len(users))
         assert (df == 0).all().all()
-        assert df.name == 'EndUse'
         assert list(df.columns) == ['user_1', 'user_2', 'user_3']
 
     def test_probability_distribution(self):
         """Base usage_probability returns a valid normalised distribution."""
-        prob = EndUse.usage_probability() 
+        prob = EndUse.usage_probability()
         assert isinstance(prob, pd.Series)
         assert len(prob) == N_PTS
         assert prob.sum() == pytest.approx(1.0)
@@ -95,7 +99,10 @@ class TestChildEndUseClasses:
         end_use = cls(statistics=nl_stats.end_uses[stats_key])
         assert isinstance(end_use, cls)
         assert isinstance(end_use.offset, int)
-        assert end_use.offset == nl_stats.end_uses[stats_key]['offset']
+        if isinstance(nl_stats.end_uses[stats_key]['offset'], str):
+            assert end_use.offset > 0
+        else:
+            assert end_use.offset == 0
 
     @pytest.mark.parametrize('cls, stats_key', [
         pytest.param(BathroomTap, 'BathroomTap', id='BathroomTap'),

--- a/testing/core/test_end_use.py
+++ b/testing/core/test_end_use.py
@@ -41,6 +41,17 @@ ALL_END_USES = [
     pytest.param(WcNew,          'Wc',             id='WcNew'),
     pytest.param(WcNewSave,      'Wc',             id='WcNewSave'),
 ]
+AGE_GENDER_CONFIG = {
+    "distribution": "Poisson",
+    "average": {
+        "child": {"male": 1.0, "female": 1.5},
+        "adult": {"male": 2.0, "female": 2.5},
+    },
+}
+NUMUSERS_CONFIG = {
+    "distribution": "Poisson",
+    "average": {"1": 0.5, "2": 1.0, "3": 1.5},
+}
 
 
 @pytest.fixture(scope='module')
@@ -88,6 +99,41 @@ class TestParentEndUseClass:
         assert len(prob) == N_PTS
         assert prob.sum() == pytest.approx(1.0)
         assert (prob >= 0).all()
+
+    @pytest.mark.parametrize("dist_config, call_kwargs, exp_name, exp_params", [
+        pytest.param({"distribution": "Poisson", "lam": 2.5}, {}, "Poisson", {"lam": 2.5}, id="constant-poisson"),  # Constant (no optional args)
+        pytest.param({"distribution": "Uniform", "low": 0, "high": 1}, {}, "Uniform", {"low": 0, "high": 1}, id="constant-uniform"),
+        pytest.param({"distribution": "Poisson", "average": {"child": 1.0, "adult": 2.0}}, {"age": "child"}, "Poisson", {"average": 1.0}, id="age-child"),  # Age resolution
+        pytest.param(AGE_GENDER_CONFIG, {"age": "child", "gender": "male"}, "Poisson", {"average": 1.0}, id="age-gender-child-male"),  # Age + gender resolution
+        pytest.param(NUMUSERS_CONFIG, {"numusers": 1}, "Poisson", {"average": 0.5}, id="numusers-1"),  # Numusers resolution (int -> str lookup)
+        pytest.param(NUMUSERS_CONFIG, {"numusers": 3}, "Poisson", {"average": 1.5}, id="numusers-3"),
+        pytest.param({"distribution": "Negative_binomial", "n": 1, "p": {"child": 0.3, "adult": 0.5}}, {"age": "child"}, "Negative_binomial", {"n": 1, "p": 0.3}, id="mixed-child"),  # Mixed: scalar params pass through, only dict-valued params are resolved
+    ])
+    def test_get_statistical_params_success(self, end_use, dist_config, call_kwargs, exp_name, exp_params):
+        """All resolution modes return (str, dict) with the correct values."""
+        result = end_use.get_statistical_params(dist_config, **call_kwargs)
+        assert isinstance(result, tuple) and len(result) == 2
+        assert isinstance(result[0], str)
+        assert isinstance(result[1], dict)
+        assert result[0] == exp_name
+        assert result[1] == exp_params
+
+    def test_get_statistical_params_no_mutation(self, end_use):
+        """The original dist_config dict must not be modified."""
+        original = {"distribution": "Poisson", "average": {"child": 1.0}}
+        copy = {"distribution": "Poisson", "average": {"child": 1.0}}
+        end_use.get_statistical_params(original, age="child")
+        assert original == copy
+
+    @pytest.mark.parametrize("dist_config, call_kwargs", [
+        pytest.param({}, {}, id="missing-distribution-key"),
+        pytest.param(AGE_GENDER_CONFIG, {"age": "nonexistent"}, id="invalid-age"),
+        pytest.param(NUMUSERS_CONFIG, {"numusers": 99}, id="invalid-numusers"),
+    ])
+    def test_raises_on_invalid_input(self, end_use, dist_config, call_kwargs):
+        """Missing or mismatched keys raise KeyError."""
+        with pytest.raises(KeyError):
+            end_use.get_statistical_params(dist_config, **call_kwargs)
 
 
 class TestChildEndUseClasses:

--- a/testing/core/test_statistics.py
+++ b/testing/core/test_statistics.py
@@ -8,6 +8,7 @@ import os
 import pytest
 from unittest.mock import patch
 
+import toml
 from pysimdeum.core.statistics import Statistics
 from pysimdeum.data import DATA_DIR
 
@@ -52,7 +53,7 @@ class TestStatisticsCustomDir:
         stats = Statistics(country=real_dir)
         assert stats.country is None
         assert stats.statisticsdir == real_dir
-        assert len(stats.end_uses) == 8
+        assert len(stats.end_uses) == len(EXPECTED_END_USE_KEYS)
 
 
 class TestStatisticsHousehold:
@@ -110,12 +111,20 @@ class TestStatisticsConvertToDict:
             return Statistics()
 
     def test_plain_dict(self):
-        """Plain dict passes through."""
-        assert self._instance()._convert_to_dict({'a': 1}) == {'a': 1}
+        """Plain dict and TOML dict pass through."""
+        expected = {'a': 1}
+        assert self._instance()._convert_to_dict(expected) == expected
+        toml_dict = toml.decoder.TomlDecoder().get_empty_inline_table()
+        toml_dict['a'] = 1
+        assert self._instance()._convert_to_dict(toml_dict) == expected
 
     def test_nested_dict(self):
-        """Nested dict is recursed."""
-        assert self._instance()._convert_to_dict({'x': {'y': 2}}) == {'x': {'y': 2}}
+        """Nested dict and TOML dict are recursed."""
+        expected = {'x': {'y': 2}}
+        assert self._instance()._convert_to_dict(expected) == expected
+        nested_toml_dict = {'x': toml.decoder.TomlDecoder().get_empty_inline_table()}
+        nested_toml_dict['x']['y'] = 2
+        assert self._instance()._convert_to_dict(nested_toml_dict) == expected
 
     def test_list_of_ints(self):
         """List of ints passes through."""
@@ -137,4 +146,3 @@ class TestStatisticsConvertToDict:
     def test_empty_list(self):
         """Empty list returns empty list."""
         assert self._instance()._convert_to_dict([]) == []
-

--- a/testing/core/test_statistics.py
+++ b/testing/core/test_statistics.py
@@ -44,6 +44,7 @@ def test_statistics_country_instanciation(country):
     assert country in stats.statisticsdir
     assert os.path.isdir(stats.statisticsdir)
 
+
 class TestStatisticsCustomDir:
     """Integration test: Statistics accepts a real directory path instead of a country code."""
 
@@ -84,6 +85,8 @@ class TestStatisticsEndUses:
             assert k in nl_stats.end_uses, f'{k!r} missing from end_uses'  # k!r equivalent to repr(k)
             assert isinstance(nl_stats.end_uses[k], dict)
             assert len(nl_stats.end_uses[k]) > 0
+            assert 'frequency' in nl_stats.end_uses[k]
+            assert 'offset' in nl_stats.end_uses[k]
 
 
 class TestStatisticsPatterns:

--- a/testing/core/test_statistics.py
+++ b/testing/core/test_statistics.py
@@ -1,0 +1,140 @@
+"""
+Integration tests for the Statistics dataclass (pysimdeum.core.statistics).
+
+These tests use the real NL and UK data files that are shipped with the
+pysimdeum package — no mocking of I/O, toml.load, or pattern helpers.
+"""
+import os
+import pytest
+from unittest.mock import patch
+
+from pysimdeum.core.statistics import Statistics
+from pysimdeum.data import DATA_DIR
+
+
+# Constants derived from the real NL data layout
+EXPECTED_END_USE_KEYS = [
+    'Wc', 'Bathtub', 'BathroomTap', 'Dishwasher',
+    'KitchenTap', 'OutsideTap', 'Shower', 'WashingMachine',
+]
+EXPECTED_FULL_PATTERN_END_USES = ['WashingMachine', 'Dishwasher']
+PATTERN_KEYS_FULL = ['daily_pattern', 'enduse_pattern', 'discharge_pattern']
+
+
+# Module-scoped fixture — built once, shared across all tests
+@pytest.fixture(scope='module')
+def nl_stats():
+    """Construct Statistics('NL') once using real NL data files."""
+    return Statistics(country='NL')
+
+
+def test_statistics_default_instanciation():
+    """Smoke tests: Statistics() constructs without error."""
+    stats = Statistics()
+    assert stats is not None
+    assert stats.statisticsdir.startswith(DATA_DIR)
+    assert isinstance(stats, Statistics)
+
+@pytest.mark.parametrize('country', ['NL', 'UK'])
+def test_statistics_country_instanciation(country):
+    stats = Statistics(country=country)
+    assert stats.country == country
+    assert stats.statisticsdir.startswith(DATA_DIR)
+    assert country in stats.statisticsdir
+    assert os.path.isdir(stats.statisticsdir)
+
+class TestStatisticsCustomDir:
+    """Integration test: Statistics accepts a real directory path instead of a country code."""
+
+    def test_custom_dir_mode(self, nl_stats):
+        """Passing a real directory path loads data correctly and sets country to None."""
+        real_dir = nl_stats.statisticsdir
+        stats = Statistics(country=real_dir)
+        assert stats.country is None
+        assert stats.statisticsdir == real_dir
+        assert len(stats.end_uses) == 8
+
+
+class TestStatisticsHousehold:
+    """Tests for the household dict loaded from household_statistics.toml."""
+
+    def test_household_is_dict(self, nl_stats):
+        assert isinstance(nl_stats.household, dict)
+        assert len(nl_stats.household) > 0
+        assert all(isinstance(k, str) for k in nl_stats.household)
+
+
+class TestStatisticsDiurnalPattern:
+    """Tests for the diurnal_pattern dict loaded from diurnal_patterns.toml."""
+
+    def test_diurnal_pattern_is_dict(self, nl_stats):
+        assert isinstance(nl_stats.diurnal_pattern, dict)
+        assert len(nl_stats.diurnal_pattern) > 0
+        assert all(isinstance(k, str) for k in nl_stats.diurnal_pattern)
+
+
+class TestStatisticsEndUses:
+    """Tests for the end_uses dict populated from 8 TOML files."""
+
+    def test_end_uses_is_dict(self, nl_stats):
+        assert isinstance(nl_stats.end_uses, dict)
+        assert len(nl_stats.end_uses) == len(EXPECTED_END_USE_KEYS)
+        for k in EXPECTED_END_USE_KEYS:
+            assert k in nl_stats.end_uses, f'{k!r} missing from end_uses'  # k!r equivalent to repr(k)
+            assert isinstance(nl_stats.end_uses[k], dict)
+            assert len(nl_stats.end_uses[k]) > 0
+
+
+class TestStatisticsPatterns:
+    """Tests correct pattern initialization."""
+
+    @pytest.mark.parametrize('enduse', EXPECTED_FULL_PATTERN_END_USES)
+    @pytest.mark.parametrize('pattern', PATTERN_KEYS_FULL)
+    def test_washing_machine_has_daily_pattern(self, nl_stats, enduse, pattern):
+        """Example: check that WashingMachine has daily_pattern."""
+        assert pattern in nl_stats.end_uses[enduse]
+        assert nl_stats.end_uses[enduse][pattern] is not None
+
+    def test_kitchen_tap_has_daily_pattern(self, nl_stats):
+        """KitchenTap has daily_pattern."""
+        assert 'daily_pattern' in nl_stats.end_uses['KitchenTap']
+        assert nl_stats.end_uses['KitchenTap']['daily_pattern'] is not None
+
+
+class TestStatisticsConvertToDict:
+    """Unit tests for _convert_to_dict with __post_init__ bypassed, no real data needed."""
+
+    def _instance(self):
+        """Return a Statistics instance with __post_init__ disabled."""
+        with patch.object(Statistics, '__post_init__', lambda self: None):
+            return Statistics()
+
+    def test_plain_dict(self):
+        """Plain dict passes through."""
+        assert self._instance()._convert_to_dict({'a': 1}) == {'a': 1}
+
+    def test_nested_dict(self):
+        """Nested dict is recursed."""
+        assert self._instance()._convert_to_dict({'x': {'y': 2}}) == {'x': {'y': 2}}
+
+    def test_list_of_ints(self):
+        """List of ints passes through."""
+        assert self._instance()._convert_to_dict([1, 2, 3]) == [1, 2, 3]
+
+    def test_list_of_dicts(self):
+        """List of dicts is recursed."""
+        assert self._instance()._convert_to_dict([{'a': 1}]) == [{'a': 1}]
+
+    @pytest.mark.parametrize('value', [0, 3.14, 'hello', True, None, False])
+    def test_scalar(self, value):
+        """Scalar value passes through unchanged."""
+        assert self._instance()._convert_to_dict(value) == value
+
+    def test_empty_dict(self):
+        """Empty dict returns empty dict."""
+        assert self._instance()._convert_to_dict({}) == {}
+
+    def test_empty_list(self):
+        """Empty list returns empty list."""
+        assert self._instance()._convert_to_dict([]) == []
+

--- a/testing/utils/test_patterns.py
+++ b/testing/utils/test_patterns.py
@@ -1,11 +1,58 @@
 import pytest
 import numpy as np
+import pandas as pd
 
 from pysimdeum.utils.patterns import (
     sample_start_time,
+    complex_daily_pattern,
+    complex_enduse_pattern,
+    complex_discharge_pattern,
 )
 
 N_PTS = 24 * 60 * 60  # One point per second.
+HOURLY_PATTERN = [
+    34, 24, 17, 43, 41, 57, 57, 212, 290, 338, 392, 325, 226, 222, 200, 175, 124, 106, 139, 185,
+    133, 165, 101, 147, 34
+]
+HOURLY_CONFIG = {
+    'daily_pattern_input': {
+        'x': ' '.join(map(str, HOURLY_PATTERN)),
+    }
+}
+QUARTER_PATTERN = [
+    0.0004, 0.0002, 0.0002, 0.0001, 0.0001, 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.0001, 0.0001,
+    0.0002, 0., 0.0004, 0.0011, 0.0015, 0.0011, 0., 0.0041, 0.0072, 0.0096, 0.018, 0.018, 0.0227,
+    0.0229, 0.0221, 0.0155, 0.0153, 0.0155, 0.0139, 0.0091, 0.0087, 0.0068, 0.006, 0.0038, 0.0043,
+    0.0042, 0.0063, 0.0061, 0.0115, 0.0158, 0.0326, 0.0214, 0.0251, 0.023, 0.0237, 0.0154, 0.0117,
+    0.0072, 0.0059, 0.0037, 0.0038, 0.0029, 0.004, 0.0031, 0.0044, 0.0059, 0.0131, 0.0121, 0.0214,
+    0.0239, 0.0453, 0.0348, 0.0462, 0.0423, 0.059, 0.0393, 0.0427, 0.0336, 0.0311, 0.0176, 0.0159,
+    0.0104, 0.0075, 0.004, 0.0049, 0.0033, 0.0023, 0.0024, 0.0024, 0.0027, 0.0032, 0.0022, 0.0026,
+    0.0018, 0.0021, 0.0013, 0.0012, 0.0005, 0., 0.0004
+]
+QUARTER_CONFIG = {
+    'daily_pattern_input': {
+        'x': ' '.join(map(str, QUARTER_PATTERN))
+    }
+}
+DAILY_PATTERN_CASES = [
+    pytest.param(HOURLY_PATTERN, HOURLY_CONFIG,  '1h',    id='hourly'),
+    pytest.param(QUARTER_PATTERN, QUARTER_CONFIG, '15Min', id='15min'),
+]
+ENDUSE_CONFIG = {
+    'enduse_pattern_input': {
+        'intensity': 0.1667,
+        'runtime': 7200,
+        'cycle_times': [
+            {'start': 0,    'end': 121},
+            {'start': 3600, 'end': 3660},
+            {'start': 4920, 'end': 4980},
+            {'start': 6120, 'end': 6180},
+        ],
+    },
+    'discharge_pattern_input': {
+        'discharge_time': 60,
+    },
+}
 
 
 @pytest.fixture
@@ -25,56 +72,164 @@ def peak_prob_joint():
     return prob_joint / prob_joint.sum()
 
 
-@pytest.mark.parametrize("prob_joint_type", ["uniform", "peak"])
-@pytest.mark.parametrize("day_num", [0, 1])
-@pytest.mark.parametrize("duration", [60, 600])
-@pytest.mark.parametrize("previous_events", [
-    [],  # No previous events.
-    [(0, 10 * 60 * 60)],  # One previous event covering the first 10 hours of the first day.
-])
-@pytest.mark.parametrize("offset", [0, 7200])
-def test_sample_start_time(prob_joint_type, day_num, duration, previous_events, offset, uniform_prob_joint, peak_prob_joint):
-    """Tests the sample_start_time function under normal use."""
-    peak_radius = 30
-    if prob_joint_type == "uniform":
-        prob_joint = uniform_prob_joint
-    else:
-        prob_joint = peak_prob_joint
+class TestSampleStartTime:
+    @pytest.mark.parametrize("prob_joint_type", ["uniform", "peak"])
+    @pytest.mark.parametrize("day_num", [0, 1])
+    @pytest.mark.parametrize("duration", [60, 600])
+    @pytest.mark.parametrize("previous_events", [
+        [],  # No previous events.
+        [(0, 10 * 60 * 60)],  # One previous event covering the first 10 hours of the first day.
+    ])
+    @pytest.mark.parametrize("offset", [0, 7200])
+    def test_sample_start_time(self, prob_joint_type, day_num, duration, previous_events, offset, uniform_prob_joint, peak_prob_joint):
+        """Tests the sample_start_time function under normal use."""
+        peak_radius = 30
+        if prob_joint_type == "uniform":
+            prob_joint = uniform_prob_joint
+        else:
+            prob_joint = peak_prob_joint
 
-    start, end = sample_start_time(prob_joint, day_num, duration, previous_events, offset)
-    assert isinstance(start, int)
-    assert isinstance(end, int)
-    assert (end - start) == duration
-    assert start >= day_num * N_PTS
-    # Test that the probability distribution is respected
-    if prob_joint_type == "peak":
-        assert day_num * N_PTS + N_PTS // 2 - peak_radius <= start <= day_num * N_PTS + N_PTS // 2 + peak_radius
+        start, end = sample_start_time(prob_joint, day_num, duration, previous_events, offset)
+        assert isinstance(start, int)
+        assert isinstance(end, int)
+        assert (end - start) == duration
+        assert start >= day_num * N_PTS
+        # Test that the probability distribution is respected
+        if prob_joint_type == "peak":
+            assert day_num * N_PTS + N_PTS // 2 - peak_radius <= start <= day_num * N_PTS + N_PTS // 2 + peak_radius
 
-    # Test that the sampled time does not overlap with any previous events
-    for event_start, event_end in previous_events:
-        assert not (
-            (event_start <= start < event_end + offset)
-            or (start < event_start <= start + int(duration) + offset)
-        ), f"Sampled start {start}, end {end} overlaps with previous event ({event_start}, {event_end}) with offset {offset}"
-
-
-def test_sample_start_time_empty_prob_joint():
-    """Test with an empty prob_joint, expecting an error from np.random.choice."""
-    prob_joint = np.array([])
-    day_num = 0
-    duration = 60
-    previous_events = []
-    with pytest.raises(ValueError, match="a must be greater than 0"):
-        sample_start_time(prob_joint, day_num, duration, previous_events)
+        # Test that the sampled time does not overlap with any previous events
+        for event_start, event_end in previous_events:
+            assert not (
+                (event_start <= start < event_end + offset)
+                or (start < event_start <= start + int(duration) + offset)
+            ), f"Sampled start {start}, end {end} overlaps with previous event ({event_start}, {event_end}) with offset {offset}"
 
 
-def test_sample_start_time_inf_loop(peak_prob_joint):
-    """Test against infinite loops when all conditions are invalid."""
-    with pytest.raises(RuntimeError, match="Could not find a valid start time"):
-        previous_events = [(0, 24 * 60 * 60)]  # One previous event covering the full day.
-        sample_start_time(
-            prob_joint=peak_prob_joint,
-            day_num=0,
-            duration=60,
-            previous_events=previous_events
+    def test_sample_start_time_empty_prob_joint(self):
+        """Test with an empty prob_joint, expecting an error from np.random.choice."""
+        prob_joint = np.array([])
+        day_num = 0
+        duration = 60
+        previous_events = []
+        with pytest.raises(ValueError, match="a must be greater than 0"):
+            sample_start_time(prob_joint, day_num, duration, previous_events)
+
+
+    def test_sample_start_time_inf_loop(self, peak_prob_joint):
+        """Test against infinite loops when all conditions are invalid."""
+        with pytest.raises(RuntimeError, match="Could not find a valid start time"):
+            previous_events = [(0, 24 * 60 * 60)]  # One previous event covering the full day.
+            sample_start_time(
+                prob_joint=peak_prob_joint,
+                day_num=0,
+                duration=60,
+                previous_events=previous_events
+            )
+
+
+class TestComplexDailyPattern:
+    """Behavioural tests for complex_daily_pattern."""
+
+    @pytest.mark.parametrize('pattern,config,freq', DAILY_PATTERN_CASES)
+    def test_output_structure(self, pattern, config, freq):
+        """Output is an 86400-point TimedeltaIndex Series with no NaNs."""
+        result = complex_daily_pattern(config, freq=freq)
+        assert isinstance(result, pd.Series)
+        assert isinstance(result.index, pd.TimedeltaIndex)
+        assert len(result) == N_PTS
+        assert not result.isna().any()
+
+    @pytest.mark.parametrize('pattern,config,freq', DAILY_PATTERN_CASES)
+    def test_output_values(self, pattern, config, freq):
+        """All values are finite and non-negative after resampling and interpolation."""
+        result = complex_daily_pattern(config, freq=freq)
+        assert (result >= 0).all()
+        assert np.isfinite(result.values).all()
+        assert result.max() <= max(pattern)
+        assert result.min() >= min(pattern)
+        assert all(x in result.values for x in pattern)
+
+    @pytest.mark.parametrize('bad_freq', ['30Min', '2h', '10s', 'D'])
+    def test_invalid_freq_raises(self, bad_freq):
+        """Unsupported freq values raise ValueError."""
+        with pytest.raises(ValueError, match='freq'):
+            complex_daily_pattern(HOURLY_CONFIG, freq=bad_freq)
+
+
+class TestComplexEndusePattern:
+    """Behavioural tests for complex_enduse_pattern."""
+
+    def test_output_structure(self):
+        """Output is a runtime-length TimedeltaIndex Series with no NaNs."""
+        enduse_pat = complex_enduse_pattern(ENDUSE_CONFIG)
+        runtime = ENDUSE_CONFIG['enduse_pattern_input']['runtime']
+        assert isinstance(enduse_pat, pd.Series)
+        assert isinstance(enduse_pat.index, pd.TimedeltaIndex)
+        assert len(enduse_pat) == runtime
+        assert not enduse_pat.isna().any()
+
+    def test_only_two_values(self):
+        """Series contains exactly two distinct values: 0.0 and the configured intensity."""
+        enduse_pat = complex_enduse_pattern(ENDUSE_CONFIG)
+        intensity = ENDUSE_CONFIG['enduse_pattern_input']['intensity']
+        unique = set(np.round(enduse_pat.unique(), 4))
+        assert unique == {0.0, round(intensity, 4)}
+
+    def test_cycle_values(self):
+        """Correct intensity or zero at known positions relative to cycle windows."""
+        enduse_pat = complex_enduse_pattern(ENDUSE_CONFIG)
+        idx_expected = [
+            (0,    0.1667),  # start of cycle 1
+            (100,  0.1667),  # inside cycle 1
+            (200,  0.0),     # after cycle 1 end (121), before cycle 2
+            (3600, 0.1667),  # start of cycle 2
+            (3630, 0.1667),  # inside cycle 2
+            (3700, 0.0),     # after cycle 2 end (3660)
+            (4920, 0.1667),  # start of cycle 3
+            (6120, 0.1667),  # start of cycle 4
+            (6200, 0.0),     # after cycle 4 end (6180)
+        ]
+        assert all(enduse_pat.iloc[i] == pytest.approx(x, abs=1e-4) for i, x in idx_expected)
+
+
+@pytest.fixture(scope='module')
+def end_use_discharge_pat():
+    """Real discharge pattern from ENDUSE_CONFIG."""
+    eup = complex_enduse_pattern(ENDUSE_CONFIG)
+    return eup, complex_discharge_pattern(ENDUSE_CONFIG, eup)
+
+
+class TestComplexDischargePattern:
+    """Behavioural tests for complex_discharge_pattern."""
+
+    def test_output_structure(self, end_use_discharge_pat):
+        """Output is a runtime-length TimedeltaIndex Series with no NaNs."""
+        discharge_pat = end_use_discharge_pat[1]
+        runtime = ENDUSE_CONFIG['enduse_pattern_input']['runtime']
+        assert isinstance(discharge_pat, pd.Series)
+        assert isinstance(discharge_pat.index, pd.TimedeltaIndex)
+        assert len(discharge_pat) == runtime
+        assert not discharge_pat.isna().any()
+
+    def test_discharge_occurs_and_is_valid(self, end_use_discharge_pat):
+        """Discharge events exist, are all non-negative, and sum to a positive total."""
+        discharge_pat = end_use_discharge_pat[1]
+        assert (discharge_pat >= 0).all()
+        assert (discharge_pat > 0).any()
+        assert discharge_pat.sum() > 0
+
+    def test_no_overlap_with_enduse(self, end_use_discharge_pat):
+        """Discharge never fires simultaneously with active end-use consumption."""
+        enduse_pat, discharge_pat = end_use_discharge_pat
+        overlap = (enduse_pat > 0) & (discharge_pat > 0)
+        assert not overlap.any(), (
+            f'Found {overlap.sum()} time steps where discharge overlaps active consumption'
         )
+
+    def test_water_conservation(self, end_use_discharge_pat):
+        """Total discharge volume equals total consumed volume within 5% tolerance."""
+        enduse_pat, discharge_pat = end_use_discharge_pat
+        total_consumed = enduse_pat.sum()
+        total_discharged = discharge_pat.sum()
+        assert total_discharged == pytest.approx(total_consumed, rel=0.05)

--- a/testing/utils/test_probability.py
+++ b/testing/utils/test_probability.py
@@ -1,0 +1,48 @@
+"""Unit tests for the probability utility functions (pysimdeum.utils.probability)"""
+import pytest
+import numpy as np
+from pysimdeum.utils.probability import (
+    sample_value
+)
+
+
+VALID_CASES = [
+    pytest.param('Poisson',           {'average': 2.5},               0,      6,  id='poisson-average'),
+    pytest.param('Poisson',           {'average': 0.80},              0,      2,  id='poisson-average-low'),
+    pytest.param('Poisson',           {'lam': 0.80},                  0,      4,  id='poisson-lam'),
+    pytest.param('Lognormal',         {'average': '57 Seconds'},      0,   6000,  id='lognormal-str-avg'),
+    pytest.param('Uniform',           {'low': 0., 'high': 0.167},     0,  0.167,  id='uniform-small'),
+    pytest.param('Uniform',           {'low': 20, 'high': 40},       20,     40,  id='uniform-int-range'),
+    pytest.param('Negative_binomial', {'average': 10.1, 'sigma': 7},  0,     71,  id='nb-average-sigma'),
+    pytest.param('Negative_binomial', {'n': 2.622, 'p': 0.206},       0,     71,  id='nb-n-p'),
+    pytest.param('Binomial',          {'n': 1, 'p': 0.69},            0,      1,  id='binomial'),
+    pytest.param('Chisquare',         {'df': '9.3 Minutes'},          0,   5160,  id='chisquare-str-df'),
+]
+
+INVALID_CASES = [
+    pytest.param('Poisson',           {'lambda': 3.8},          id='poisson-wrong-kwarg'),
+    pytest.param('Binomial',          {'n': 3},                 id='binomial-missing-p'),
+    pytest.param('Binomial',          {'n': 1, 'p': 2.13},      id='binomial-p-gt-1'),
+    pytest.param('Binomial',          {'n': 1, 'sigma': 2.13},  id='binomial-wrong-kwarg'),
+    pytest.param('very_special_dist', {'average': 29},          id='unsupported-dist'),
+]
+
+
+class TestSampleValue:
+    @pytest.mark.parametrize('dist_name, kwargs, lower, upper', VALID_CASES)
+    def test_valid_config_returns_value_in_range(self, dist_name, kwargs, lower, upper):
+        """Valid configs return a numeric scalar within expected bounds."""
+        result = sample_value(dist_name, **kwargs)
+        assert isinstance(result, (int, float, np.integer, np.floating))
+        assert lower <= result <= upper
+
+    @pytest.mark.parametrize('dist_name, kwargs', INVALID_CASES)
+    def test_invalid_config_raises_value_error(self, dist_name, kwargs):
+        """Invalid or unsupported configs raise ValueError."""
+        with pytest.raises((ValueError, TypeError)):
+            sample_value(dist_name, **kwargs)
+
+    def test_sampling_is_stochastic(self):
+        """Repeated calls produce varying results."""
+        values = {sample_value('Uniform', low=0, high=1000) for __ in range(20)}
+        assert len(values) > 1


### PR DESCRIPTION
Fixes #100.

## Overview

- Cleanup of the `Statistics` class.
- Cleanup of the `EndUse` class.
- Addition of unit tests in the `core` and `utils` modules.
- Addition of two functions to support the new feature. Breaking change!
- Documentation of the new feature.

## Examples

Change the frequency distribution in `Shower.toml`.
I tested both configurations below which work.

```toml
[frequency]
    distribution = 'Poisson'
    [frequency.average]
        child = 0.38
        teen = 1.12
        work_ad = 1.17
        home_ad = 0.95
        senior = 0.76
        total = 0.98
```

```toml
[frequency]
    distribution = 'Uniform'
    high = 2
    [frequency.low]
        child = 0
        teen = 1
        work_ad = 1
        home_ad = 0
        senior = 0
        total = 0
```

## Development notes

I started with `Statistics` because I thought that I could embed the distribution directly in this class.
However, it does not work because the parameters of some distribution depend on the user or house that they are generated for, like the shower example above.
I had to pivot from this idea to adding the feature in `EndUse`.
Hence the seemingly needless refactoring of `core.statistics`.